### PR TITLE
fix(quality): treat dotted dict keys as a single key

### DIFF
--- a/src/rules/quality.rs
+++ b/src/rules/quality.rs
@@ -490,6 +490,15 @@ fn is_statement_terminator(token: Option<&Token>) -> bool {
 // ---------------------------------------------------------------------------
 
 /// Warn about duplicate keys in dictionary literals.
+///
+/// A key is compared as a whole expression, not a single token: a dotted key
+/// such as `Enums.E.KEY_A` is treated as one key, so two distinct enum entries
+/// (`Enums.E.KEY_A` and `Enums.E.KEY_B`) are not mistaken for a duplicate `.`
+/// (issue #8). String-literal segments are normalized to their semantic value
+/// so `{"foo": 1, 'foo': 2}` is still caught regardless of quote style.
+///
+/// Only the depth-1 keys of each literal are considered; keys inside a nested
+/// dictionary value are left to that value's own scan.
 pub fn check_duplicate_dict_key(
     tokens: &[Token],
     file: &ScriptFile,
@@ -498,17 +507,20 @@ pub fn check_duplicate_dict_key(
     let mut i = 0;
     while i < tokens.len() {
         if tokens[i].kind == TokenKind::LeftBrace {
-            // Scan this dictionary literal for duplicate keys
+            // Scan this dictionary literal for duplicate keys.
             let mut keys: HashMap<String, Span> = HashMap::new();
             let mut depth = 1;
             let mut j = i + 1;
             let mut expect_key = true;
+            // The current key expression, accumulated token-by-token until the
+            // `:` that ends it, so multi-token keys compare as a single unit.
+            let mut key_parts: Vec<String> = Vec::new();
+            let mut key_span: Option<Span> = None;
 
             while j < tokens.len() && depth > 0 {
                 match &tokens[j].kind {
                     TokenKind::LeftBrace => {
                         depth += 1;
-                        expect_key = true;
                     }
                     TokenKind::RightBrace => {
                         depth -= 1;
@@ -516,10 +528,31 @@ pub fn check_duplicate_dict_key(
                             break;
                         }
                     }
-                    TokenKind::Colon if depth == 1 => {
+                    TokenKind::Colon if depth == 1 && expect_key => {
+                        // End of the key expression: record it as one unit.
+                        if let Some(span) = key_span.take() {
+                            let key_text = key_parts.join("");
+                            if let Some(prev_span) = keys.get(&key_text) {
+                                diagnostics.push(Diagnostic::warning(
+                                    "quality/duplicate-dict-key",
+                                    format!(
+                                        "duplicate dictionary key '{}' (first seen at line {})",
+                                        key_text, prev_span.line
+                                    ),
+                                    span,
+                                    &file.path,
+                                ));
+                            } else {
+                                keys.insert(key_text, span);
+                            }
+                        }
+                        key_parts.clear();
                         expect_key = false;
                     }
                     TokenKind::Comma if depth == 1 => {
+                        // Next entry begins; drop any partially seen value.
+                        key_parts.clear();
+                        key_span = None;
                         expect_key = true;
                     }
                     TokenKind::Newline => {}
@@ -527,25 +560,14 @@ pub fn check_duplicate_dict_key(
                         // Use the semantic value for string keys so
                         // `{"foo": 1, 'foo': 2}` is detected as a duplicate
                         // (same value, different surrounding quotes).
-                        let key_text = match &tokens[j].kind {
+                        let part = match &tokens[j].kind {
                             TokenKind::String(info) => info.value.clone(),
                             _ => tokens[j].text.clone(),
                         };
-                        if let Some(prev_span) = keys.get(&key_text) {
-                            diagnostics.push(Diagnostic::warning(
-                                "quality/duplicate-dict-key",
-                                format!(
-                                    "duplicate dictionary key '{}' (first seen at line {})",
-                                    key_text, prev_span.line
-                                ),
-                                tokens[j].span,
-                                &file.path,
-                            ));
-                        } else {
-                            keys.insert(key_text, tokens[j].span);
+                        if key_span.is_none() {
+                            key_span = Some(tokens[j].span);
                         }
-                        // After seeing a key token, don't re-flag composite keys
-                        // (we only detect simple single-token keys)
+                        key_parts.push(part);
                     }
                     _ => {}
                 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -4026,6 +4026,88 @@ func test() -> Dictionary:
     );
 }
 
+#[test]
+fn quality_duplicate_dict_key_enum_key_from_other_class_ok() {
+    // Regression (issue #8): the exact user reproduction. A dotted key like
+    // `Enums.E.KEY_A` was scanned token-by-token, so the two `.` tokens
+    // collided into a bogus `duplicate dictionary key '.'`.
+    let config = default_config();
+    let source = "\
+extends Node
+
+const _DEFS: Dictionary = {
+\tEnums.E.KEY_A: {
+\t\t\"value_1\": \"A\",
+\t},
+}
+";
+    let diagnostics = linter::lint_source(source, "test.gd", &config);
+    assert!(
+        !diagnostics
+            .iter()
+            .any(|d| d.rule == "quality/duplicate-dict-key"),
+        "a single dotted enum key must not self-collide, got: {:?}",
+        diagnostics
+            .iter()
+            .filter(|d| d.rule == "quality/duplicate-dict-key")
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn quality_duplicate_dict_key_distinct_dotted_keys_ok() {
+    // Two different enum entries used as keys are distinct, not duplicates.
+    let config = default_config();
+    let source = "\
+extends Node
+
+const _DEFS: Dictionary = {
+\tEnums.E.KEY_A: {
+\t\t\"value_1\": \"A\",
+\t},
+\tEnums.E.KEY_B: {
+\t\t\"value_1\": \"B\",
+\t},
+}
+";
+    let diagnostics = linter::lint_source(source, "test.gd", &config);
+    assert!(
+        !diagnostics
+            .iter()
+            .any(|d| d.rule == "quality/duplicate-dict-key"),
+        "distinct dotted keys must not be flagged as duplicates"
+    );
+}
+
+#[test]
+fn quality_duplicate_dict_key_same_dotted_key_detected() {
+    // A genuinely repeated dotted key is still caught after the fix.
+    let config = default_config();
+    let source = "\
+func test() -> Dictionary:
+\treturn {
+\t\tEnums.E.KEY_A: 1,
+\t\tEnums.E.KEY_A: 2,
+\t}
+";
+    let diagnostics = linter::lint_source(source, "test.gd", &config);
+    let hits: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| d.rule == "quality/duplicate-dict-key")
+        .collect();
+    assert_eq!(
+        hits.len(),
+        1,
+        "a repeated dotted key should be flagged exactly once, got {}",
+        hits.len()
+    );
+    assert!(
+        hits[0].message.contains("Enums.E.KEY_A"),
+        "message should name the full dotted key, got: {}",
+        hits[0].message
+    );
+}
+
 // --- duplicated-load ---
 
 #[test]


### PR DESCRIPTION
## Summary

`quality/duplicate-dict-key` recorded every key-position token separately and never stopped after the first one, so a dotted key such as `Enums.E.KEY_A` was scanned as five separate keys (`Enums`, `.`, `E`, `.`, `KEY_A`) and the two `.` tokens collided into a bogus `duplicate dictionary key '.'`. Anyone keying a dict by an enum from another class got flooded with these. The scanner now accumulates the whole key expression up to its `:` and compares it as a single unit, keeping the existing string-value normalization so mixed quote styles still collide. Genuine duplicates, including a repeated dotted key like `Enums.E.KEY_A` twice, are still caught.

## Type

- [x] Bug fix (`fix:`) — non-breaking change that resolves an issue

## Test plan

Added three integration regression tests in `tests/integration_test.rs`, including the reporter's exact reproduction:

- the exact user example (`{ Enums.E.KEY_A: { ... } }`) no longer warns
- two distinct dotted keys (`Enums.E.KEY_A` and `Enums.E.KEY_B`) don't collide
- a genuinely repeated dotted key is still flagged exactly once, with the full key name in the message
- existing `{"a": 1, "b": 2, "a": 3}` positive and `{"a": {"a": 1}}` nested-ok tests still pass

- [x] `cargo test` passes locally (`test result: ok. 174 passed` lib, `244 passed` integration)
- [x] `cargo clippy --release` is clean
- [x] If this touches a rule or the formatter: relevant regression tests added

## Linked issues

Closes #8
