### PR TITLE
ci: add rustfmt, clippy and test jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,63 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  rustfmt:
+    name: rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+
+      - name: Check formatting
+        run: cargo fmt --all --check
+
+  clippy:
+    name: clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - name: Cache cargo build
+        uses: Swatinem/rust-cache@v2
+
+      - name: Clippy (deny warnings)
+        run: cargo clippy --release --all-targets -- -D warnings
+
+  test:
+    name: test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo build
+        uses: Swatinem/rust-cache@v2
+
+      - name: Test
+        run: cargo test --release

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -169,7 +169,7 @@ impl<'a> Lexer<'a> {
                 return None;
             }
             i += 1; // step past '\n'
-            // Measure leading whitespace of this line.
+                    // Measure leading whitespace of this line.
             let mut indent = 0;
             while i < self.chars.len() {
                 match self.chars[i] {
@@ -1353,9 +1353,7 @@ world""""#;
         // string; it is not an unterminated string.
         let tokens = tokenize("var s = \"line one\nline two\"\n");
         assert!(
-            !tokens
-                .iter()
-                .any(|t| matches!(t.kind, TokenKind::Error(_))),
+            !tokens.iter().any(|t| matches!(t.kind, TokenKind::Error(_))),
             "multi-line regular string must not be an Error token: {:?}",
             tokens
         );
@@ -1369,9 +1367,7 @@ world""""#;
     fn genuinely_unterminated_string_is_an_error() {
         // A string with no closing quote before EOF is still an error.
         let tokens = tokenize("var s = \"no closing quote\n");
-        assert!(tokens
-            .iter()
-            .any(|t| matches!(t.kind, TokenKind::Error(_))));
+        assert!(tokens.iter().any(|t| matches!(t.kind, TokenKind::Error(_))));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -339,8 +339,7 @@ fn run_check(
                         result.was_fixed = true;
                     }
                     // Re-lint to report remaining issues.
-                    result.diagnostics =
-                        linter::lint_source(&fixed_source, &file_str, &config);
+                    result.diagnostics = linter::lint_source(&fixed_source, &file_str, &config);
                 } else {
                     result.diagnostics = diagnostics;
                 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -719,9 +719,9 @@ impl<'t> Parser<'t> {
                 let mut peek = self.position;
                 while peek < self.tokens.len() {
                     match &self.tokens[peek].kind {
-                        TokenKind::Newline
-                        | TokenKind::DocComment(_)
-                        | TokenKind::Comment(_) => peek += 1,
+                        TokenKind::Newline | TokenKind::DocComment(_) | TokenKind::Comment(_) => {
+                            peek += 1
+                        }
                         TokenKind::Dedent => {
                             return end_line.saturating_sub(start_line) + 1;
                         }

--- a/src/rules/formatting.rs
+++ b/src/rules/formatting.rs
@@ -1032,10 +1032,7 @@ pub fn check_colon_spacing(
         // `=`, a space after the `=`. The Assign rule handles space-after-`=`;
         // here we just skip both the "no space before" and "space after"
         // checks when this colon is the leading half of `:=`.
-        let is_walrus = source
-            .as_bytes()
-            .get(token.span.offset + token.span.length)
-            == Some(&b'=');
+        let is_walrus = source.as_bytes().get(token.span.offset + token.span.length) == Some(&b'=');
 
         // No space before the colon (skipped for `:=`).
         if !is_walrus && token.span.offset > 0 {
@@ -1082,7 +1079,10 @@ pub fn check_colon_spacing(
         let token_end = token.span.offset + token.span.length;
         if token_end < source.len() {
             let next_byte = source.as_bytes().get(token_end);
-            let no_space_required = matches!(next_byte, Some(&b'=') | Some(&b'\n') | Some(&b' ') | Some(&b'\t'));
+            let no_space_required = matches!(
+                next_byte,
+                Some(&b'=') | Some(&b'\n') | Some(&b' ') | Some(&b'\t')
+            );
             if !no_space_required {
                 // Also tolerate when the next token IS a Newline (the byte
                 // check above already handles `\n`, but be defensive about
@@ -1173,12 +1173,7 @@ pub fn check_comma_spacing(
             let next_byte = source.as_bytes().get(token_end);
             let no_space_required = matches!(
                 next_byte,
-                Some(&b' ')
-                    | Some(&b'\t')
-                    | Some(&b'\n')
-                    | Some(&b')')
-                    | Some(&b']')
-                    | Some(&b'}')
+                Some(&b' ') | Some(&b'\t') | Some(&b'\n') | Some(&b')') | Some(&b']') | Some(&b'}')
             );
             if !no_space_required {
                 diagnostics.push(

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1738,7 +1738,9 @@ fn fmt_stacked_class_annotations_preserve_source_order() {
     let config = default_config();
     let formatted = formatter::format_source(source, &config);
     let abs = formatted.find("@abstract").expect("missing @abstract");
-    let exp = formatted.find("@experimental").expect("missing @experimental");
+    let exp = formatted
+        .find("@experimental")
+        .expect("missing @experimental");
     let dep = formatted.find("@deprecated").expect("missing @deprecated");
     assert!(
         abs < exp && exp < dep,
@@ -1896,9 +1898,7 @@ static func get_active_artifacts(equipped) -> Array:
     // attached (regression guard against breaking the working case
     // while fixing the broken one).
     assert!(
-        formatted.contains(
-            "## Executes the resolution via signals.\nstatic func resolve_skills("
-        ),
+        formatted.contains("## Executes the resolution via signals.\nstatic func resolve_skills("),
         "multi-line docstring on resolve_skills was detached, got:\n{}",
         formatted
     );
@@ -3154,7 +3154,8 @@ fn fmt_regular_var_with_value_unaffected_by_computed_property_handling() {
 
 #[test]
 fn fmt_colon_spacing_in_type_hints() {
-    let source = "extends Node\n\nconst X:float = 1.0\nvar y:int = 0\n@export var z:Dictionary = {}\n";
+    let source =
+        "extends Node\n\nconst X:float = 1.0\nvar y:int = 0\n@export var z:Dictionary = {}\n";
     let formatted = formatter::format_source(source, &default_config());
     assert!(
         formatted.contains("const X: float = 1.0"),
@@ -3186,7 +3187,8 @@ fn fmt_colon_spacing_in_function_parameters() {
 
 #[test]
 fn fmt_colon_spacing_strips_space_before_block_colon() {
-    let source = "extends Node\n\nfunc _ready() :\n\tif true :\n\t\tpass\n\twhile false :\n\t\tpass\n";
+    let source =
+        "extends Node\n\nfunc _ready() :\n\tif true :\n\t\tpass\n\twhile false :\n\t\tpass\n";
     let formatted = formatter::format_source(source, &default_config());
     assert!(
         formatted.contains("func _ready():"),
@@ -3300,7 +3302,8 @@ fn fmt_combined_colon_and_comma_fixes_match_canonical_godot_form() {
     let source = "extends Node\n\nfunc add_item(item_id:String,count:int = 1,rarity:int = 0) -> bool :\n\tvar pairs = [{\"a\":1,\"b\":2}, {\"c\":3,\"d\":4}]\n\treturn true\n";
     let formatted = formatter::format_source(source, &default_config());
     assert!(
-        formatted.contains("func add_item(item_id: String, count: int = 1, rarity: int = 0) -> bool:"),
+        formatted
+            .contains("func add_item(item_id: String, count: int = 1, rarity: int = 0) -> bool:"),
         "combined signature spacing, got:\n{}",
         formatted
     );


### PR DESCRIPTION
## Summary

Adds a `CI` workflow that runs on every pull request (and on pushes to `main`) so open PRs are validated automatically. Three independent jobs:

- **rustfmt** — `cargo fmt --all --check`
- **clippy** — `cargo clippy --release --all-targets -- -D warnings`
- **test** — `cargo test --release` on Linux, macOS, and Windows

Includes a one-off `style: apply cargo fmt` commit because the tree was not clean under current stable rustfmt (13 cosmetic reflows across `lexer.rs`, `parser.rs`, `formatting.rs`, `main.rs`, and the integration tests). That commit is separate so it is easy to review on its own, and it makes the new rustfmt gate green.

## Type

- [x] CI / build (`ci:` / `build:`)

## Test plan

- [x] `cargo fmt --all --check` is clean after the fmt commit
- [x] `cargo clippy --release --all-targets -- -D warnings` is clean
- [x] `cargo test --release` passes locally (`174` lib, `247` integration)

## Linked issues

N/A
