### PR TITLE
feat(order): honor per-member order/class-member-order ignore

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,6 +445,31 @@ file-by-file, set it to `"off"` in `gdstyle.toml` instead:
 The TOML config and inline suppressions are independent; either one
 silencing a rule is enough to drop the diagnostic.
 
+#### Pinning a member against reordering
+
+`order/class-member-order` is enforced by the formatter, so ignoring it
+does double duty: it silences the `check` diagnostic *and* pins the
+member where you wrote it, so `gdstyle fmt` won't move it. Everything
+else still reorders around the pinned member. This is handy when two
+declarations are meant to sit together, for example a `const` lookup
+table kept next to the `enum` it mirrors:
+
+```gdscript
+enum SaveGameFormat {
+	BINARY,
+	TEXT,
+}
+# gdstyle:ignore=order/class-member-order
+const SAVE_GAME_FORMAT_DISPLAY_NAMES: PackedStringArray = [
+	"OPTIONS_GENERAL_BINARY",
+	"OPTIONS_GENERAL_TEXT",
+]
+```
+
+The directive may sit directly above the declaration (or above its
+annotations). A `# gdstyle:ignore-file=order/class-member-order` pins
+every member, disabling reordering for the whole file.
+
 ## CLI reference
 
 ```

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -1290,6 +1290,7 @@ fn same_member_signatures(a: &[ClassMember], b: &[ClassMember]) -> bool {
 
 /// A reorderable class member: the source span it occupies plus its ordering
 /// category and original position (for a stable sort).
+#[derive(Clone, Copy)]
 struct Block {
     /// 0-indexed first line, including any attached comments / annotations.
     start: usize,
@@ -1409,8 +1410,26 @@ fn reorder_class_members(source: &str) -> String {
 
     let attached_starts = compute_attached_starts(&merged, &lines);
 
-    // Build blocks. Each block spans from its attached_start to just before
-    // the next block's attached_start (or end of file for the last block).
+    // A member carrying a `# gdstyle:ignore=order/class-member-order` directive
+    // opts out of reordering: it is pinned to its source position while the
+    // rest normalise around it. We look for the directive anywhere in the
+    // member's header (its attached comments/annotations through its
+    // declaration line), so it can sit above the annotations too.
+    let suppressions = crate::linter::Suppressions::parse(source);
+    let pinned: Vec<bool> = merged
+        .iter()
+        .enumerate()
+        .map(|(i, &(decl_line, _, _))| {
+            suppressions.suppresses_member(
+                attached_starts[i] + 1,
+                decl_line + 1,
+                "order/class-member-order",
+            )
+        })
+        .collect();
+
+    // Build blocks in source order. Each block spans from its attached_start to
+    // just before the next block's attached_start (or end of file for the last).
     let mut blocks: Vec<Block> = Vec::new();
     for (i, &(_, cat, orig)) in merged.iter().enumerate() {
         let start = attached_starts[i];
@@ -1427,14 +1446,38 @@ fn reorder_class_members(source: &str) -> String {
         });
     }
 
-    // Stable sort by category.
-    blocks.sort_by(|a, b| {
+    // Fixed-point stable sort: pinned blocks keep their source position; the
+    // remaining blocks are stably sorted by (category, original_index) and slot
+    // into the free positions in order. With no pins this reduces to the plain
+    // category sort.
+    let mut movable = blocks
+        .iter()
+        .zip(&pinned)
+        .filter(|&(_, &p)| !p)
+        .map(|(b, _)| *b)
+        .collect::<Vec<Block>>();
+    movable.sort_by(|a, b| {
         a.category
             .cmp(&b.category)
             .then(a.original_index.cmp(&b.original_index))
     });
+    let mut movable = movable.into_iter();
+    let ordered: Vec<Block> = blocks
+        .iter()
+        .zip(&pinned)
+        .map(|(b, &p)| {
+            if p {
+                *b
+            } else {
+                // Exactly one movable block per non-pinned slot by construction.
+                movable
+                    .next()
+                    .expect("movable block for each non-pinned slot")
+            }
+        })
+        .collect();
 
-    emit_reordered_blocks(&blocks, &lines, &attached_starts)
+    emit_reordered_blocks(&ordered, &lines, &attached_starts)
 }
 
 /// Reconstruct the source with `blocks` in their new (sorted) order,
@@ -1884,5 +1927,55 @@ func take_damage(amount: int) -> void:
         let expected = "extends Node\n\n# Section header\n\nconst A := 1\n";
         let config = Config::default();
         assert_eq!(format_source(source, &config), expected);
+    }
+
+    // Enhancement (issue #16): a member tagged with
+    // `# gdstyle:ignore=order/class-member-order` is pinned in place, so a const
+    // kept next to the enum it mirrors stays between the two enums instead of
+    // being hoisted into the constants group. We assert ordering (the feature's
+    // guarantee) rather than exact whitespace, which is a separate concern.
+    #[test]
+    fn order_ignore_directive_pins_member_in_place() {
+        let source = "extends Node\n\n\
+             enum E {\n\tA,\n}\n\
+             # gdstyle:ignore=order/class-member-order\n\
+             const NAMES := [\"a\"]\n\
+             enum F {\n\tB,\n}\n";
+        let config = Config::default();
+        let positions = |text: &str| {
+            (
+                text.find("enum E").unwrap(),
+                text.find("const NAMES").unwrap(),
+                text.find("enum F").unwrap(),
+            )
+        };
+        let result = format_source(source, &config);
+        let (e, c, f) = positions(&result);
+        assert!(
+            e < c && c < f,
+            "pinned const must stay between its enums, got:\n{result}"
+        );
+        // Pinned ordering must be idempotent.
+        let (e2, c2, f2) = positions(&format_source(&result, &config));
+        assert!(e2 < c2 && c2 < f2, "pinned order must be stable");
+    }
+
+    // Control: without the directive the same members reorder canonically
+    // (all enums grouped ahead of the const). Confirms pinning is opt-in.
+    #[test]
+    fn reorder_still_groups_members_without_directive() {
+        let source = "extends Node\n\n\
+             enum E {\n\tA,\n}\n\
+             const NAMES := [\"a\"]\n\
+             enum F {\n\tB,\n}\n";
+        let config = Config::default();
+        let result = format_source(source, &config);
+        let enum_e = result.find("enum E").unwrap();
+        let enum_f = result.find("enum F").unwrap();
+        let const_pos = result.find("const NAMES").unwrap();
+        assert!(
+            enum_e < enum_f && enum_f < const_pos,
+            "enums should group ahead of the const, got:\n{result}"
+        );
     }
 }

--- a/src/linter.rs
+++ b/src/linter.rs
@@ -93,12 +93,36 @@ pub fn lint_file(path: &std::path::Path, config: &Config) -> Result<Vec<Diagnost
 /// the rule list means "suppress all diagnostics in this scope"; `Some`
 /// means "suppress only these rules".
 #[derive(Default)]
-struct Suppressions {
+pub(crate) struct Suppressions {
     /// Per-line: indexed by line number so `is_suppressed` is O(1).
     per_line: std::collections::HashMap<usize, Vec<Option<Vec<String>>>>,
     /// Per-file: all `# gdstyle:ignore-file` directives merged together,
     /// regardless of where they appear in the source.
     file_level: Vec<Option<Vec<String>>>,
+}
+
+impl Suppressions {
+    /// Parse every suppression directive out of `source`.
+    pub(crate) fn parse(source: &str) -> Self {
+        parse_suppression_comments(source)
+    }
+
+    /// True when `rule` is suppressed for a member whose header spans lines
+    /// `first..=last` (1-based, inclusive) — that is, a `# gdstyle:ignore-file`
+    /// covering the rule, or a per-line `# gdstyle:ignore` that resolves onto
+    /// any line of that header. Used both to pin a member against reordering
+    /// and to exempt it from the `order/class-member-order` check, so `fmt` and
+    /// `check` agree on which members opt out.
+    pub(crate) fn suppresses_member(&self, first: usize, last: usize, rule: &str) -> bool {
+        if self.file_level.iter().any(|r| matches_rule_list(r, rule)) {
+            return true;
+        }
+        (first..=last).any(|line| {
+            self.per_line
+                .get(&line)
+                .is_some_and(|lists| lists.iter().any(|r| matches_rule_list(r, rule)))
+        })
+    }
 }
 
 /// Parse suppression comments. Two forms are recognised:

--- a/src/rules/ordering.rs
+++ b/src/rules/ordering.rs
@@ -1,5 +1,6 @@
 use crate::ast::{ClassMember, ScriptFile};
 use crate::diagnostic::Diagnostic;
+use crate::linter::Suppressions;
 
 /// Check that class members follow the canonical ordering.
 ///
@@ -20,12 +21,20 @@ use crate::diagnostic::Diagnostic;
 /// 14. Custom methods
 /// 15. Inner classes
 pub fn check_class_member_order(file: &ScriptFile, diagnostics: &mut Vec<Diagnostic>) {
-    check_member_order_recursive(&file.members, &file.path, diagnostics);
+    // Members carrying a `# gdstyle:ignore=order/class-member-order` directive
+    // opt out of the ordering check. They are skipped entirely — neither
+    // flagged nor counted towards the running "highest category seen" — so a
+    // pinned member (e.g. a const kept next to the enum it mirrors) does not
+    // make its neighbours look out of order. This mirrors how the formatter's
+    // reorder pass pins the same members in place.
+    let suppressions = Suppressions::parse(&file.lines.join("\n"));
+    check_member_order_recursive(&file.members, &file.path, &suppressions, diagnostics);
 }
 
 fn check_member_order_recursive(
     members: &[ClassMember],
     file_path: &str,
+    suppressions: &Suppressions,
     diagnostics: &mut Vec<Diagnostic>,
 ) {
     let mut highest_category_seen: usize = 0;
@@ -35,6 +44,11 @@ fn check_member_order_recursive(
 
         // Skip comments and blank lines (they don't affect ordering).
         if category == usize::MAX {
+            continue;
+        }
+
+        // Skip members that opted out of the ordering rule.
+        if is_order_ignored(member, suppressions) {
             continue;
         }
 
@@ -75,9 +89,28 @@ fn check_member_order_recursive(
 
         // Recursively check inner classes.
         if let ClassMember::InnerClass { members: inner, .. } = member {
-            check_member_order_recursive(inner, file_path, diagnostics);
+            check_member_order_recursive(inner, file_path, suppressions, diagnostics);
         }
     }
+}
+
+/// True when `member` carries a `# gdstyle:ignore` directive covering
+/// `order/class-member-order` (or a file-level one). The directive may sit
+/// directly above the declaration or above any of its leading annotations.
+fn is_order_ignored(member: &ClassMember, suppressions: &Suppressions) -> bool {
+    let decl_line = member.span().line;
+    let header_start = match member {
+        ClassMember::Variable { annotations, .. }
+        | ClassMember::Function { annotations, .. }
+        | ClassMember::StaticVariable { annotations, .. } => annotations
+            .iter()
+            .map(|a| a.span.line)
+            .min()
+            .map(|a| a.min(decl_line))
+            .unwrap_or(decl_line),
+        _ => decl_line,
+    };
+    suppressions.suppresses_member(header_start, decl_line, "order/class-member-order")
 }
 
 #[cfg(test)]
@@ -251,6 +284,99 @@ mod tests {
         let mut diags = Vec::new();
         check_class_member_order(&file, &mut diags);
         assert_eq!(diags.len(), 1);
+    }
+
+    #[test]
+    fn order_ignore_directive_exempts_member_and_neighbours() {
+        // Layout (1-based lines):
+        //   1  extends Node
+        //   2  enum First {...}       (enum, category 5)
+        //   3  # gdstyle:ignore=order/class-member-order
+        //   4  const NAMES := [...]   (const, category 6, pinned)
+        //   5  enum Second {...}      (enum, category 5)
+        // The pinned const must not raise the ordering bar, so the trailing
+        // enum (5) after it is not flagged.
+        let file = ScriptFile {
+            path: "test.gd".to_string(),
+            lines: vec![
+                "extends Node".to_string(),
+                "enum First { A }".to_string(),
+                "# gdstyle:ignore=order/class-member-order".to_string(),
+                "const NAMES := [\"a\"]".to_string(),
+                "enum Second { B }".to_string(),
+            ],
+            members: vec![
+                ClassMember::ExtendsDecl {
+                    base: "Node".to_string(),
+                    span: span(1),
+                },
+                ClassMember::Enum {
+                    name: Some("First".to_string()),
+                    name_span: Some(span(2)),
+                    members: vec![],
+                    span: span(2),
+                },
+                ClassMember::Constant {
+                    name: "NAMES".to_string(),
+                    name_span: span(4),
+                    type_hint: None,
+                    span: span(4),
+                },
+                ClassMember::Enum {
+                    name: Some("Second".to_string()),
+                    name_span: Some(span(5)),
+                    members: vec![],
+                    span: span(5),
+                },
+            ],
+        };
+
+        let mut diags = Vec::new();
+        check_class_member_order(&file, &mut diags);
+        assert!(
+            diags.is_empty(),
+            "pinned const should exempt itself and its neighbours, got: {:?}",
+            diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn order_violation_without_directive_still_flagged() {
+        // Same shape as above but with no ignore directive: the trailing enum
+        // after the const is a genuine ordering violation and must be reported.
+        let file = ScriptFile {
+            path: "test.gd".to_string(),
+            lines: vec![
+                "enum First { A }".to_string(),
+                "const NAMES := [\"a\"]".to_string(),
+                "enum Second { B }".to_string(),
+            ],
+            members: vec![
+                ClassMember::Enum {
+                    name: Some("First".to_string()),
+                    name_span: Some(span(1)),
+                    members: vec![],
+                    span: span(1),
+                },
+                ClassMember::Constant {
+                    name: "NAMES".to_string(),
+                    name_span: span(2),
+                    type_hint: None,
+                    span: span(2),
+                },
+                ClassMember::Enum {
+                    name: Some("Second".to_string()),
+                    name_span: Some(span(3)),
+                    members: vec![],
+                    span: span(3),
+                },
+            ],
+        };
+
+        let mut diags = Vec::new();
+        check_class_member_order(&file, &mut diags);
+        assert_eq!(diags.len(), 1);
+        assert!(diags[0].message.contains("enum declaration"));
     }
 
     #[test]


### PR DESCRIPTION
Closes #16.

`order/class-member-order` is enforced by the formatter's reorder pass, so a `# gdstyle:ignore=order/class-member-order` comment was treated as a plain comment and the member got reordered anyway.

The directive now pins the member: the reorder keeps pinned blocks at their source position and stably sorts the rest around them, so a const can be kept next to the enum it mirrors. The lint rule skips pinned members too (neither flagged nor counted toward the running category), so `check` and `fmt` agree on which members opt out. A file-level ignore pins every member. Both sides share one `Suppressions` helper for consistent detection.

Documented under "Pinning a member against reordering" in the README.

Tests: 4 tests (pin keeps order + idempotent, reorder still groups without the directive, lint exempts pinned member and its neighbours, real violations still flagged). Full suite, clippy, and rustfmt clean.