### PR TITLE
fix: pad single-line dict braces and strip space before call parens

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ gdstyle catches style violations, naming inconsistencies, and common code-qualit
 
 ## Features
 
-- 54 lint rules across syntax, naming, formatting, ordering, and code quality.
+- 56 lint rules across syntax, naming, formatting, ordering, and code quality.
 - Formatter (`gdstyle fmt`) that's in-place and idempotent, and reorders class members into the canonical Godot order.
 - Auto-fix: `--fix` for the safe ones, `--unsafe-fix` for renames. Renames follow into other `.gd` files and into the `.tscn`/`.tres` scene wiring.
 - Single static binary. No Python, no Rust toolchain, no Godot install required to run it.
@@ -111,7 +111,7 @@ gdstyle check --max-line-length 120
 
 ## Rules
 
-gdstyle ships with 54 rules organized into five categories. Most rules are enabled by default (a few advisory rules are opt-in).
+gdstyle ships with 56 rules organized into five categories. Most rules are enabled by default (a few advisory rules are opt-in).
 
 ### Syntax (1 rule)
 
@@ -135,7 +135,7 @@ gdstyle ships with 54 rules organized into five categories. Most rules are enabl
 | `naming/private-underscore-prefix` | Private members with `_` should not have `@export` | - |
 | `naming/node-name-pascal-case` | `$NodePath` references should use `PascalCase` | unsafe |
 
-### Formatting (18 rules)
+### Formatting (20 rules)
 
 | Rule | Description | Fixable |
 |------|-------------|---------|
@@ -154,6 +154,8 @@ gdstyle ships with 54 rules organized into five categories. Most rules are enabl
 | `format/operator-spacing` | One space around binary operators | safe |
 | `format/colon-spacing` | No space before `:`, one space after (except `:=` and end of line) | safe |
 | `format/comma-spacing` | No space before `,`, one space after (except newline / closing bracket) | safe |
+| `format/brace-spacing` | Single-line dictionary literals need a space after `{` and before `}` | safe |
+| `format/call-paren-spacing` | No space between a callee and its opening `(` | safe |
 | `format/float-literal-zeros` | Float literals need leading/trailing zeros (`0.5`, not `.5`) | safe |
 | `format/large-number-underscores` | Large numbers (>=10000) should use underscores | safe |
 | `format/enum-one-per-line` | Each enum member on its own line | safe |
@@ -651,7 +653,7 @@ gdstyle/
 │   └── rules/
 │       ├── mod.rs           # Rule dispatcher
 │       ├── naming.rs        # 11 naming convention rules
-│       ├── formatting.rs    # 18 formatting rules
+│       ├── formatting.rs    # 20 formatting rules
 │       ├── ordering.rs      # Class member ordering rule
 │       └── quality.rs       # 23 code quality rules
 ├── gdstyle-gdext/           # GDExtension wrapper (exposes linter/formatter to Godot)

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -908,13 +908,13 @@ fn try_break_comment(line: &str, max_len: usize) -> Option<Vec<String>> {
         return None;
     }
 
-    // Extract the comment prefix (# or ##) and the text.
+    // Extract the comment prefix (# or ##) and the text. A bare `#`, a `#!`
+    // shebang, or any non-comment line yields None (the `?` on the `# `
+    // branch), so we never try to wrap those.
     let (prefix, text) = if let Some(rest) = content.strip_prefix("## ") {
         ("## ", rest)
-    } else if let Some(rest) = content.strip_prefix("# ") {
-        ("# ", rest)
     } else {
-        return None; // Don't break #! shebangs or bare # lines.
+        ("# ", content.strip_prefix("# ")?)
     };
 
     let prefix_visual_len = visual_line_len(&format!("{}{}", indent, prefix), TAB_WIDTH);

--- a/src/rules/formatting.rs
+++ b/src/rules/formatting.rs
@@ -1197,6 +1197,173 @@ pub fn check_comma_spacing(
     }
 }
 
+/// Enforce single-line dictionary literals pad their braces with a space
+/// (`{key = "value"}` -> `{ key = "value" }`), per the Godot style guide's
+/// explicit exception for dictionaries (unlike arrays, which get no inner
+/// padding). Enum bodies also use `{}` in GDScript but are not dictionaries,
+/// so they're excluded by checking whether the brace immediately follows the
+/// `enum` keyword (optionally via an enum name). Empty dicts (`{}`) and
+/// multi-line dicts are left alone: there's nothing to pad in the former, and
+/// the opening/closing braces already sit on their own lines in the latter.
+pub fn check_brace_spacing(
+    tokens: &[Token],
+    file: &ScriptFile,
+    source: &str,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    for (idx, token) in tokens.iter().enumerate() {
+        if token.kind != TokenKind::LeftBrace {
+            continue;
+        }
+
+        // Skip enum bodies: `enum {A, B}` or `enum Name {A, B}`.
+        if idx > 0 {
+            let prev = &tokens[idx - 1];
+            let is_anonymous_enum = prev.kind == TokenKind::Enum;
+            let is_named_enum = matches!(prev.kind, TokenKind::Identifier(_))
+                && idx > 1
+                && tokens[idx - 2].kind == TokenKind::Enum;
+            if is_anonymous_enum || is_named_enum {
+                continue;
+            }
+        }
+
+        // Find the matching closing brace, tracking nested depth so inner
+        // dictionaries are checked independently.
+        let mut depth = 1;
+        let mut close_idx = None;
+        for (offset, candidate) in tokens[idx + 1..].iter().enumerate() {
+            match candidate.kind {
+                TokenKind::LeftBrace => depth += 1,
+                TokenKind::RightBrace => {
+                    depth -= 1;
+                    if depth == 0 {
+                        close_idx = Some(idx + 1 + offset);
+                        break;
+                    }
+                }
+                _ => {}
+            }
+        }
+        let Some(close_idx) = close_idx else {
+            continue;
+        };
+        let close_token = &tokens[close_idx];
+
+        // Only single-line dictionary literals get padded.
+        if token.span.line != close_token.span.line {
+            continue;
+        }
+        // Empty dict: nothing to pad.
+        if close_idx == idx + 1 {
+            continue;
+        }
+
+        let open_end = token.span.offset + token.span.length;
+        let byte_after = source.as_bytes().get(open_end);
+        if byte_after != Some(&b' ') && byte_after != Some(&b'\t') {
+            diagnostics.push(
+                Diagnostic::warning(
+                    "format/brace-spacing",
+                    "add space after '{' in single-line dictionary literal".to_string(),
+                    token.span,
+                    &file.path,
+                )
+                .with_fix(Fix {
+                    replacements: vec![Replacement {
+                        offset: open_end,
+                        length: 0,
+                        new_text: " ".to_string(),
+                    }],
+                    is_safe: true,
+                }),
+            );
+        }
+
+        if close_token.span.offset > 0 {
+            let byte_before = source.as_bytes().get(close_token.span.offset - 1);
+            if byte_before != Some(&b' ') && byte_before != Some(&b'\t') {
+                diagnostics.push(
+                    Diagnostic::warning(
+                        "format/brace-spacing",
+                        "add space before '}' in single-line dictionary literal".to_string(),
+                        close_token.span,
+                        &file.path,
+                    )
+                    .with_fix(Fix {
+                        replacements: vec![Replacement {
+                            offset: close_token.span.offset,
+                            length: 0,
+                            new_text: " ".to_string(),
+                        }],
+                        is_safe: true,
+                    }),
+                );
+            }
+        }
+    }
+}
+
+/// No space between a callee and its opening `(`: `print ("foo")` should be
+/// `print("foo")`. Applies to identifiers (function/method calls), chained
+/// calls (`get_callback() ()`), calls on a subscript result
+/// (`handlers[i] ()`), and the builtin call-like keywords `preload`,
+/// `assert`, and `super`. Control-flow keywords (`if`, `while`, `return`,
+/// ...) aren't calls and keep whatever paren spacing they already have; a
+/// literal newline between the callee and `(` is also left alone since it's
+/// never an ordinary call.
+pub fn check_call_paren_spacing(
+    tokens: &[Token],
+    file: &ScriptFile,
+    source: &str,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    for (idx, token) in tokens.iter().enumerate() {
+        if token.kind != TokenKind::LeftParen || idx == 0 {
+            continue;
+        }
+        let prev = &tokens[idx - 1];
+        let is_call_like = matches!(
+            prev.kind,
+            TokenKind::Identifier(_)
+                | TokenKind::RightParen
+                | TokenKind::RightBracket
+                | TokenKind::Preload
+                | TokenKind::Assert
+                | TokenKind::Super
+        );
+        if !is_call_like {
+            continue;
+        }
+
+        let prev_end = prev.span.offset + prev.span.length;
+        if token.span.offset <= prev_end {
+            continue;
+        }
+        let gap = &source[prev_end..token.span.offset];
+        if gap.is_empty() || !gap.chars().all(|c| c == ' ' || c == '\t') {
+            continue;
+        }
+
+        diagnostics.push(
+            Diagnostic::warning(
+                "format/call-paren-spacing",
+                "no space before '(' in a function call".to_string(),
+                token.span,
+                &file.path,
+            )
+            .with_fix(Fix {
+                replacements: vec![Replacement {
+                    offset: prev_end,
+                    length: token.span.offset - prev_end,
+                    new_text: String::new(),
+                }],
+                is_safe: true,
+            }),
+        );
+    }
+}
+
 /// Check enum members are each on their own line.
 pub fn check_enum_one_per_line(
     file: &ScriptFile,

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -109,6 +109,16 @@ pub fn run_all_rules_with_source(
             formatting::check_comma_spacing(tokens, file, src, &mut diagnostics);
         }
     }
+    if config.is_rule_enabled("format/brace-spacing") {
+        if let Some(src) = source {
+            formatting::check_brace_spacing(tokens, file, src, &mut diagnostics);
+        }
+    }
+    if config.is_rule_enabled("format/call-paren-spacing") {
+        if let Some(src) = source {
+            formatting::check_call_paren_spacing(tokens, file, src, &mut diagnostics);
+        }
+    }
     if config.is_rule_enabled("format/float-literal-zeros") {
         formatting::check_float_literal_zeros(tokens, file, &mut diagnostics);
     }
@@ -304,6 +314,14 @@ pub fn all_rules() -> &'static [(&'static str, &'static str)] {
         (
             "format/comma-spacing",
             "No space before ',' and one space after (except newline / closing bracket)",
+        ),
+        (
+            "format/brace-spacing",
+            "Single-line dictionary literals need a space after '{' and before '}'",
+        ),
+        (
+            "format/call-paren-spacing",
+            "No space between a callee and its opening '('",
         ),
         (
             "format/float-literal-zeros",

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -2481,7 +2481,7 @@ fn fmt_inner_class_preserves_multiline_body() {
         "static func body preserved"
     );
     assert!(
-        formatted.contains("{\"hp\": hp, \"mp\": mp}"),
+        formatted.contains("{ \"hp\": hp, \"mp\": mp }"),
         "to_dict body preserved"
     );
     // Virtual `_init` comes before the static method.
@@ -3230,7 +3230,7 @@ fn fmt_colon_spacing_in_dict_keys() {
     let source = "extends Node\n\nvar d = {\"a\":1, \"b\":2}\n";
     let formatted = formatter::format_source(source, &default_config());
     assert!(
-        formatted.contains("{\"a\": 1, \"b\": 2}"),
+        formatted.contains("{ \"a\": 1, \"b\": 2 }"),
         "dict keys: missing space after ':', got:\n{}",
         formatted
     );
@@ -3260,7 +3260,7 @@ fn fmt_comma_spacing_in_array_and_dict_literals() {
         formatted
     );
     assert!(
-        formatted.contains("{\"a\": 1, \"b\": 2, \"c\": 3}"),
+        formatted.contains("{ \"a\": 1, \"b\": 2, \"c\": 3 }"),
         "dict literal: missing space after ',', got:\n{}",
         formatted
     );
@@ -3295,6 +3295,116 @@ fn fmt_comma_spacing_preserves_trailing_comma() {
     );
 }
 
+// --- Brace-spacing regression suite -------------------------------------------
+// Style guide: single-line dictionary literals get a space after '{' and
+// before '}' (the one exception to "avoid extra spaces").
+
+#[test]
+fn fmt_brace_spacing_pads_single_line_dict() {
+    let source = "extends Node\n\nvar my_dictionary = {key = \"value\"}\n";
+    let formatted = formatter::format_source(source, &default_config());
+    assert!(
+        formatted.contains("{ key = \"value\" }"),
+        "single-line dict must be padded, got:\n{}",
+        formatted
+    );
+}
+
+#[test]
+fn fmt_brace_spacing_leaves_empty_dict_alone() {
+    let source = "extends Node\n\nvar d = {}\n";
+    let formatted = formatter::format_source(source, &default_config());
+    assert!(
+        formatted.contains("var d = {}"),
+        "empty dict must not be padded, got:\n{}",
+        formatted
+    );
+}
+
+#[test]
+fn fmt_brace_spacing_pads_nested_dicts() {
+    let source = "extends Node\n\nvar d = {a = {b = 1}}\n";
+    let formatted = formatter::format_source(source, &default_config());
+    assert!(
+        formatted.contains("{ a = { b = 1 } }"),
+        "nested dicts must each be padded, got:\n{}",
+        formatted
+    );
+}
+
+#[test]
+fn fmt_brace_spacing_skips_enum_bodies() {
+    // Enums use `{}` too, but they aren't dictionaries and must not be padded.
+    let source = "extends Node\n\nenum Single {ONLY}\n";
+    let formatted = formatter::format_source(source, &default_config());
+    assert!(
+        formatted.contains("enum Single {ONLY}"),
+        "enum body must not be padded like a dict, got:\n{}",
+        formatted
+    );
+}
+
+#[test]
+fn fmt_brace_spacing_leaves_multiline_dict_alone() {
+    let source = "extends Node\n\nvar d = {\n\t\"a\": 1,\n\t\"b\": 2,\n}\n";
+    let formatted = formatter::format_source(source, &default_config());
+    assert!(
+        formatted.contains("d = {\n\t\"a\": 1,"),
+        "multi-line dict braces must not be padded, got:\n{}",
+        formatted
+    );
+}
+
+// --- Call-paren-spacing regression suite --------------------------------------
+// Style guide: no space between a callee and its opening '(', e.g.
+// `print ("foo")` -> `print("foo")`.
+
+#[test]
+fn fmt_call_paren_spacing_strips_space_before_call() {
+    let source = "extends Node\n\nfunc f() -> void:\n\tprint (\"foo\")\n";
+    let formatted = formatter::format_source(source, &default_config());
+    assert!(
+        formatted.contains("print(\"foo\")"),
+        "call must not have space before '(', got:\n{}",
+        formatted
+    );
+}
+
+#[test]
+fn fmt_call_paren_spacing_strips_space_before_chained_and_preload() {
+    let source = "extends Node\n\nfunc f() -> void:\n\tget_callback() ()\n\tpreload (\"res://x.tscn\")\n\tassert (true)\n";
+    let formatted = formatter::format_source(source, &default_config());
+    assert!(
+        formatted.contains("get_callback()()"),
+        "chained call must not have space before '(', got:\n{}",
+        formatted
+    );
+    assert!(
+        formatted.contains("preload(\"res://x.tscn\")"),
+        "preload must not have space before '(', got:\n{}",
+        formatted
+    );
+    assert!(
+        formatted.contains("assert(true)"),
+        "assert must not have space before '(', got:\n{}",
+        formatted
+    );
+}
+
+#[test]
+fn fmt_call_paren_spacing_preserves_if_condition_parens() {
+    // `if (x):` isn't a call; no-unnecessary-parens (not call-paren-spacing)
+    // owns stripping those parens, so the space before them is irrelevant
+    // here as long as call-paren-spacing doesn't touch it.
+    let source = "extends Node\n\nfunc f() -> void:\n\tif (x > 5):\n\t\tpass\n";
+    let formatted = formatter::format_source(source, &default_config());
+    assert!(
+        !formatted.contains("if(x"),
+        "if-condition parens must not be treated as a call, got:\n{}",
+        formatted
+    );
+}
+
 #[test]
 fn fmt_combined_colon_and_comma_fixes_match_canonical_godot_form() {
     // End-to-end regression covering A1+A2+A3 together against a realistic
@@ -3308,7 +3418,8 @@ fn fmt_combined_colon_and_comma_fixes_match_canonical_godot_form() {
         formatted
     );
     assert!(
-        formatted.contains("{\"a\": 1, \"b\": 2}") && formatted.contains("{\"c\": 3, \"d\": 4}"),
+        formatted.contains("{ \"a\": 1, \"b\": 2 }")
+            && formatted.contains("{ \"c\": 3, \"d\": 4 }"),
         "combined dict spacing, got:\n{}",
         formatted
     );


### PR DESCRIPTION
## Summary

Fixes #20. Two whitespace cases from the [official Godot style guide](https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_styleguide.html#whitespace) had no corresponding rule, so `gdstyle fmt` reported "already formatted" while leaving them untouched.

### Before → after

```gdscript
# input
my_dictionary = {key = "value"}
print ("foo")

# gdstyle fmt output (now)
my_dictionary = { key = "value" }
print("foo")
```

## New rules (both safe-fixable, enabled by default)

- **`format/brace-spacing`** — single-line dictionary literals get a space after `{` and before `}`. The style guide calls this out as the one explicit exception to "avoid extra spaces," to visually distinguish dicts from arrays. Correctly leaves alone:
  - enum bodies (`enum State {IDLE}` — uses `{}` but isn't a dict)
  - empty dicts (`{}`)
  - multi-line dicts (braces already on their own lines)
  - nested dicts are each padded independently
- **`format/call-paren-spacing`** — no space between a callee and its opening `(`. Covers identifiers, chained calls (`get_callback() ()`), subscript-result calls (`handlers[i] ()`), and the call-like keywords `preload` / `assert` / `super`. Control-flow keyword parens (`if (x):`) and lambda `func (...)` are deliberately untouched — `no-unnecessary-parens` owns the former.

## Tests

- 8 new integration tests covering padding, empty/nested/multi-line dicts, enum exclusion, chained calls, `preload`/`assert`, and if-condition non-interference.
- Fixed 4 existing tests that had asserted the old unpadded-dict output as correct.
- Full suite green (256 integration + 3 doctests), `cargo clippy` clean, `cargo fmt --check` clean.

Docs (README rule table + counts) updated: 54 → 56 total, 18 → 20 formatting rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)