### PR TITLE
fix(fixer): preserve CRLF offsets and line endings when applying fixes

### DIFF
--- a/src/fixer.rs
+++ b/src/fixer.rs
@@ -87,6 +87,15 @@ pub struct CrossFileReference {
 /// assert_eq!(fixed, "var x = 1\n");
 /// ```
 pub fn apply_fixes(source: &str, diagnostics: &[Diagnostic], safe_only: bool) -> String {
+    // `diagnostics` was produced by `linter::lint_source`, which normalizes
+    // `\r\n`/`\r` to `\n` before computing byte offsets (see
+    // `normalize_line_endings`). Normalize here too so those offsets land on
+    // the right bytes, then restore the original line-ending convention on
+    // the way out so CRLF files stay CRLF.
+    let has_crlf = source.contains('\r');
+    let normalized = crate::linter::normalize_line_endings(source);
+    let source = normalized.as_str();
+
     // Single tokenize + parse pass for everything we need below.
     let mut lexer = Lexer::new(source);
     let tokens = lexer.tokenize();
@@ -182,11 +191,17 @@ pub fn apply_fixes(source: &str, diagnostics: &[Diagnostic], safe_only: bool) ->
         }
     }
 
-    if replacements.is_empty() {
-        return source.to_string();
-    }
+    let fixed = if replacements.is_empty() {
+        source.to_string()
+    } else {
+        apply_replacements(source, replacements)
+    };
 
-    apply_replacements(source, replacements)
+    if has_crlf {
+        fixed.replace('\n', "\r\n")
+    } else {
+        fixed
+    }
 }
 
 fn apply_replacements(source: &str, replacements: Vec<Replacement>) -> String {
@@ -205,6 +220,12 @@ pub fn extract_renames(
     file_path: &str,
     members: &[ClassMember],
 ) -> Vec<AppliedRename> {
+    // `diagnostics` carries byte offsets computed against the LF-normalized
+    // source (see `apply_fixes` for the full rationale), so normalize here
+    // too before slicing `source` with those offsets.
+    let normalized = crate::linter::normalize_line_endings(source);
+    let source = normalized.as_str();
+
     let class_name = extract_class_name(members);
     let existing_names = collect_existing_names(members);
     let mut lexer = Lexer::new(source);
@@ -1103,5 +1124,31 @@ mod tests {
         let diags: Vec<Diagnostic> = vec![];
         let result = apply_fixes(source, &diags, true);
         assert_eq!(result, source);
+    }
+
+    // Regression test for https://github.com/atelico/gdstyle/issues/24:
+    // `lint_source` computes diagnostic offsets against an internally
+    // LF-normalized copy of the source, so a CRLF file's own `\r` bytes must
+    // not shift those offsets when the fix is applied back.
+    #[test]
+    fn apply_fixes_on_crlf_source_does_not_corrupt_offsets() {
+        let source =
+            "extends Node\r\n\r\nfunc _demo() -> void:\r\n\tvar w := _make({\"k\": 1})\r\n";
+        let diagnostics =
+            crate::linter::lint_source(source, "test.gd", &crate::config::Config::default());
+        let fixed = apply_fixes(source, &diagnostics, true);
+        assert_eq!(
+            fixed,
+            "extends Node\r\n\r\nfunc _demo() -> void:\r\n\tvar w := _make({ \"k\": 1 })\r\n"
+        );
+    }
+
+    #[test]
+    fn apply_fixes_preserves_crlf_line_endings_when_source_has_none_fixed() {
+        let source = "extends Node\r\n\r\nfunc _demo() -> void:\r\n\tpass\r\n";
+        let diagnostics =
+            crate::linter::lint_source(source, "test.gd", &crate::config::Config::default());
+        let fixed = apply_fixes(source, &diagnostics, true);
+        assert_eq!(fixed, source);
     }
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -3586,6 +3586,29 @@ fn formatter_handles_crlf_input() {
     );
 }
 
+// Regression test for https://github.com/atelico/gdstyle/issues/24: --fix
+// on a CRLF file must not drift replacement offsets (which corrupted
+// identifiers) and must preserve the CRLF line endings.
+#[test]
+fn fix_on_crlf_source_preserves_line_endings_and_offsets() {
+    let source = "extends Node\r\n\r\nfunc _demo() -> void:\r\n\tvar w := _make({\"k\": 1})\r\n\tvar v := _make({\"j\": 2})\r\n";
+    let config = default_config();
+    let diagnostics = linter::lint_source(source, "test.gd", &config);
+    let fixed = fixer::apply_fixes(source, &diagnostics, true);
+
+    assert!(fixed.contains("\r\n"), "CRLF endings should be preserved");
+    assert!(
+        fixed.contains("_make({ \"k\": 1 })"),
+        "identifier/brace spacing should not be corrupted, got:\n{:?}",
+        fixed
+    );
+    assert!(
+        fixed.contains("_make({ \"j\": 2 })"),
+        "identifier/brace spacing on later line should not be corrupted, got:\n{:?}",
+        fixed
+    );
+}
+
 // Naming: Vector2D, Area2D, Node3D patterns
 #[test]
 fn naming_suggests_correct_snake_case_for_2d_3d_names() {


### PR DESCRIPTION
## Summary
- `linter::lint_source` normalizes `\r\n`/`\r` to `\n` before computing diagnostic byte offsets, but `fixer::apply_fixes` and `fixer::extract_renames` applied those offsets directly to the untouched CRLF source. Each preceding CRLF line drifted the offset by one byte, so `--fix` inserted/removed characters at the wrong position and corrupted identifiers.
- Both functions now normalize the source internally before using diagnostic offsets. `apply_fixes` restores CRLF line endings on the way out so on-disk files keep their original line-ending convention.
- Covers all callers: CLI `check --fix` / `check --unsafe-fix`, and the GDExtension `fix_source` / `fix_source_unsafe` / `fix_one_in_source` / `fix_at_line` bindings used by the editor plugin.

## Test plan
- [x] `cargo test` — full suite passes (257 integration + 195 unit + 4 doctests)
- [x] `cargo clippy --release` — no new warnings
- [x] `cargo fmt --check` — clean
- [x] Manually reproduced the issue's repro file and confirmed `check --fix --select format/brace-spacing` no longer splits identifiers and preserves CRLF line endings
- [x] Manually verified `check --unsafe-fix` renames on a CRLF file work correctly
- [x] Added regression tests in `src/fixer.rs` and `tests/integration_test.rs`

Fixes #24.