### PR TITLE
fix(quality): track paren/bracket depth in duplicate-dict-key

### DIFF
--- a/src/rules/quality.rs
+++ b/src/rules/quality.rs
@@ -587,6 +587,12 @@ struct DictKeyFrame {
     key_parts: Vec<String>,
     /// Span of the first token of the current key, for the diagnostic.
     key_span: Option<Span>,
+    /// Depth of unclosed `(`/`[` within the entry currently being scanned.
+    /// A comma or colon inside a nested call or subscript (e.g. the `,` in
+    /// the key expression `Vector2i(1, 0)`) belongs to that expression, not
+    /// to this dictionary literal, and must not be mistaken for the
+    /// entry-separating comma or the key-ending colon.
+    depth: u32,
 }
 
 impl DictKeyFrame {
@@ -596,6 +602,7 @@ impl DictKeyFrame {
             expect_key: true,
             key_parts: Vec::new(),
             key_span: None,
+            depth: 0,
         }
     }
 }
@@ -617,8 +624,11 @@ pub fn check_duplicate_dict_key(
     diagnostics: &mut Vec<Diagnostic>,
 ) {
     // A stack of frames, one per currently-open `{`. Keys, commas, and colons
-    // always apply to the innermost open dictionary (`stack.last_mut()`), which
-    // routes each token to the right nesting level without a depth counter.
+    // always apply to the innermost open dictionary (`stack.last_mut()`),
+    // which routes each token to the right nesting level. Each frame also
+    // tracks its own `(`/`[` depth so a comma or colon nested inside a call
+    // or subscript within the current entry isn't mistaken for this
+    // dictionary's entry separator or key/value separator.
     let mut stack: Vec<DictKeyFrame> = Vec::new();
 
     for token in tokens {
@@ -627,9 +637,21 @@ pub fn check_duplicate_dict_key(
             TokenKind::RightBrace => {
                 stack.pop();
             }
+            TokenKind::LeftParen | TokenKind::LeftBracket => {
+                if let Some(frame) = stack.last_mut() {
+                    frame.depth += 1;
+                    push_key_part(frame, token);
+                }
+            }
+            TokenKind::RightParen | TokenKind::RightBracket => {
+                if let Some(frame) = stack.last_mut() {
+                    frame.depth = frame.depth.saturating_sub(1);
+                    push_key_part(frame, token);
+                }
+            }
             TokenKind::Colon => {
                 if let Some(frame) = stack.last_mut() {
-                    if frame.expect_key {
+                    if frame.expect_key && frame.depth == 0 {
                         // End of the key expression: record it as one unit.
                         if let Some(span) = frame.key_span.take() {
                             let key_text = frame.key_parts.join("");
@@ -649,37 +671,53 @@ pub fn check_duplicate_dict_key(
                         }
                         frame.key_parts.clear();
                         frame.expect_key = false;
+                    } else {
+                        // A `:` nested inside a call/subscript in the key
+                        // expression is part of that expression, not the
+                        // entry's key/value separator.
+                        push_key_part(frame, token);
                     }
                 }
             }
             TokenKind::Comma => {
                 if let Some(frame) = stack.last_mut() {
-                    // Next entry begins; drop any partially seen value.
-                    frame.key_parts.clear();
-                    frame.key_span = None;
-                    frame.expect_key = true;
+                    if frame.depth == 0 {
+                        // Next entry begins; drop any partially seen value.
+                        frame.key_parts.clear();
+                        frame.key_span = None;
+                        frame.expect_key = true;
+                    } else {
+                        // An argument separator inside a nested call/subscript
+                        // (e.g. `Vector2i(1, 0)`), not the entry separator.
+                        push_key_part(frame, token);
+                    }
                 }
             }
             TokenKind::Newline => {}
             _ => {
                 if let Some(frame) = stack.last_mut() {
-                    if frame.expect_key {
-                        // Use the semantic value for string keys so
-                        // `{"foo": 1, 'foo': 2}` is detected as a duplicate
-                        // (same value, different surrounding quotes).
-                        let part = match &token.kind {
-                            TokenKind::String(info) => info.value.clone(),
-                            _ => token.text.clone(),
-                        };
-                        if frame.key_span.is_none() {
-                            frame.key_span = Some(token.span);
-                        }
-                        frame.key_parts.push(part);
-                    }
+                    push_key_part(frame, token);
                 }
             }
         }
     }
+}
+
+/// Append `token` to the key expression currently being accumulated, if the
+/// frame is in key position. String tokens use their semantic value so
+/// `{"foo": 1, 'foo': 2}` is still caught regardless of quote style.
+fn push_key_part(frame: &mut DictKeyFrame, token: &Token) {
+    if !frame.expect_key {
+        return;
+    }
+    let part = match &token.kind {
+        TokenKind::String(info) => info.value.clone(),
+        _ => token.text.clone(),
+    };
+    if frame.key_span.is_none() {
+        frame.key_span = Some(token.span);
+    }
+    frame.key_parts.push(part);
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -4313,6 +4313,126 @@ func test() -> Dictionary:
     );
 }
 
+#[test]
+fn quality_duplicate_dict_key_multiarg_constructor_keys_not_duplicates() {
+    // Regression (issue #23): a comma inside a multi-argument constructor
+    // call key (`Vector2i(1, 0)`) was mistaken for the dict entry separator,
+    // so the accumulated key text collapsed to the trailing fragment `0)`
+    // and distinct keys sharing that fragment were flagged as duplicates.
+    let config = default_config();
+    let source = "\
+var fp_multiline_vec2 := {
+\tVector2i(1, 0): \"a\",
+\tVector2i(2, 0): \"b\",
+\tVector2i(3, 0): \"c\",
+}
+";
+    let diagnostics = linter::lint_source(source, "test.gd", &config);
+    assert!(
+        !diagnostics
+            .iter()
+            .any(|d| d.rule == "quality/duplicate-dict-key"),
+        "distinct Vector2i keys sharing a trailing coordinate must not be flagged, got: {:?}",
+        diagnostics
+            .iter()
+            .filter(|d| d.rule == "quality/duplicate-dict-key")
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn quality_duplicate_dict_key_singleline_multiarg_constructor_keys_not_duplicates() {
+    // Same false positive as above, single-line form from issue #23.
+    let config = default_config();
+    let source = "var fp := {Vector2i(10, 0): 0, Vector2i(8, 0): 2, Vector2i(4, 0): 6}\n";
+    let diagnostics = linter::lint_source(source, "test.gd", &config);
+    assert!(
+        !diagnostics
+            .iter()
+            .any(|d| d.rule == "quality/duplicate-dict-key"),
+        "distinct single-line Vector2i keys must not be flagged, got: {:?}",
+        diagnostics
+            .iter()
+            .filter(|d| d.rule == "quality/duplicate-dict-key")
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn quality_duplicate_dict_key_vector3i_multiarg_constructor_keys_not_duplicates() {
+    // Three-argument constructor form from issue #23.
+    let config = default_config();
+    let source = "\
+var fp_vec3 := {
+\tVector3i(0, 1, 0): \"a\",
+\tVector3i(0, 2, 0): \"b\",
+}
+";
+    let diagnostics = linter::lint_source(source, "test.gd", &config);
+    assert!(
+        !diagnostics
+            .iter()
+            .any(|d| d.rule == "quality/duplicate-dict-key"),
+        "distinct Vector3i keys sharing a trailing coordinate must not be flagged, got: {:?}",
+        diagnostics
+            .iter()
+            .filter(|d| d.rule == "quality/duplicate-dict-key")
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn quality_duplicate_dict_key_repeated_constructor_key_detected() {
+    // A genuinely repeated constructor-call key is still caught after the fix.
+    let config = default_config();
+    let source = "\
+var d := {
+\tVector2i(1, 0): \"a\",
+\tVector2i(1, 0): \"b\",
+}
+";
+    let diagnostics = linter::lint_source(source, "test.gd", &config);
+    let hits: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| d.rule == "quality/duplicate-dict-key")
+        .collect();
+    assert_eq!(
+        hits.len(),
+        1,
+        "a repeated constructor-call key should be flagged exactly once, got {}",
+        hits.len()
+    );
+    assert!(
+        hits[0].message.contains("Vector2i(1,0)"),
+        "message should name the full constructor-call key, got: {}",
+        hits[0].message
+    );
+}
+
+#[test]
+fn quality_duplicate_dict_key_constructor_args_not_confused_by_digit_boundary() {
+    // Vector2i(1, 23) and Vector2i(12, 3) must not collide even though naive
+    // concatenation of their digits without the comma would both yield "123".
+    let config = default_config();
+    let source = "\
+var d := {
+\tVector2i(1, 23): \"a\",
+\tVector2i(12, 3): \"b\",
+}
+";
+    let diagnostics = linter::lint_source(source, "test.gd", &config);
+    assert!(
+        !diagnostics
+            .iter()
+            .any(|d| d.rule == "quality/duplicate-dict-key"),
+        "constructor keys must not collide across an argument digit boundary, got: {:?}",
+        diagnostics
+            .iter()
+            .filter(|d| d.rule == "quality/duplicate-dict-key")
+            .collect::<Vec<_>>()
+    );
+}
+
 // --- duplicated-load ---
 
 #[test]


### PR DESCRIPTION
## Summary
- `quality/duplicate-dict-key` scanned key expressions token-by-token, treating every `,` as the dict entry separator and every `:` as the key/value separator, regardless of nesting. A multi-argument constructor call or subscript used as a key (e.g. `Vector2i(1, 0)`) has its own internal commas, so the key accumulator was reset mid-expression and the tracked "key" collapsed to a trailing fragment like `0)`. Unrelated keys sharing that fragment (`Vector2i(1, 0)`, `Vector2i(2, 0)`, `Vector2i(3, 0)`, ...) were then flagged as duplicates.
- Each dict frame now tracks its own `(`/`[` depth. A comma or colon is only treated as this dictionary's entry/key separator at depth 0; at greater depth it's appended to the key expression instead, so `Vector2i(1, 0)` is compared as a whole unit.
- Also fixes the same root cause on the *value* side (a nested comma inside a value's constructor call no longer prematurely flips the scanner back into "key" mode).

## Test plan
- [x] `cargo test` — full suite passes (261 integration + 193 unit + 4 doctests)
- [x] `cargo clippy --release` — no new warnings
- [x] `cargo fmt --check` — clean
- [x] Manually reproduced all three false positives from the issue (multi-line Vector2i, single-line Vector2i, Vector3i) and confirmed they're now clean
- [x] Manually verified genuine duplicates (including a repeated constructor-call key) are still caught
- [x] Added regression tests in `tests/integration_test.rs` covering the issue's exact repro cases, a true-positive repeated constructor key, and a digit-boundary collision edge case

Fixes #23.