### PR TITLE
fix(quality): duplicate-dict-key misses duplicates after a comment

### DIFF
--- a/src/rules/quality.rs
+++ b/src/rules/quality.rs
@@ -693,7 +693,7 @@ pub fn check_duplicate_dict_key(
                     }
                 }
             }
-            TokenKind::Newline => {}
+            TokenKind::Newline | TokenKind::Comment(_) | TokenKind::DocComment(_) => {}
             _ => {
                 if let Some(frame) = stack.last_mut() {
                     push_key_part(frame, token);

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -4456,6 +4456,61 @@ var d := {
     );
 }
 
+#[test]
+fn quality_duplicate_dict_key_detected_after_leading_comment() {
+    // A `#` comment sitting on its own line before the first key must not be
+    // absorbed into that key's text (issue #27), or the identical key later
+    // in the same literal no longer matches it.
+    let config = default_config();
+    let source = "\
+var d := {
+\t# a comment inside the dict literal
+\tVector3i(0, 0, 0): \"a\",
+\tVector3i(0, 0, 0): \"b\",
+}
+";
+    let diagnostics = linter::lint_source(source, "test.gd", &config);
+    let hits: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| d.rule == "quality/duplicate-dict-key")
+        .collect();
+    assert_eq!(
+        hits.len(),
+        1,
+        "a duplicate key after a leading comment should still be flagged, got {}",
+        hits.len()
+    );
+    assert!(
+        hits[0].message.contains("Vector3i(0,0,0)"),
+        "message should name the full constructor-call key, got: {}",
+        hits[0].message
+    );
+}
+
+#[test]
+fn quality_duplicate_dict_key_detected_after_trailing_comment() {
+    // A trailing `#` comment right after an entry's comma must not be
+    // absorbed into the following key's text either.
+    let config = default_config();
+    let source = "\
+var d := {
+\tVector3i(0, 0, 0): \"a\", # trailing comment
+\tVector3i(0, 0, 0): \"b\",
+}
+";
+    let diagnostics = linter::lint_source(source, "test.gd", &config);
+    let hits: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| d.rule == "quality/duplicate-dict-key")
+        .collect();
+    assert_eq!(
+        hits.len(),
+        1,
+        "a duplicate key after a trailing comment should still be flagged, got {}",
+        hits.len()
+    );
+}
+
 // --- duplicated-load ---
 
 #[test]


### PR DESCRIPTION
## Summary

`quality/duplicate-dict-key` silently stopped tracking keys for the rest of a
dictionary literal once a `#` comment appeared inside it (either on its own
line or trailing an entry), so a genuine duplicate key later in the same
literal went unreported.

## Root cause

The rule's token-scanning state machine appends every token it sees in "key
position" to the key currently being accumulated, via a catch-all match arm.
Comment tokens (`Comment`/`DocComment`) weren't excluded from that arm the
way `Newline` already is, so a comment sitting right after `{` or right after
an entry's comma got prefixed onto the following key's text. The corrupted
key no longer matched an identical key elsewhere in the literal, so the
duplicate check missed it.

## Fix

Skip `Comment` and `DocComment` tokens in the same match arm as `Newline`, so
they're never appended to the accumulated key text.

## Testing

- `quality_duplicate_dict_key_detected_after_leading_comment` — the exact
  repro from the issue (comment on its own line before the first key).
- `quality_duplicate_dict_key_detected_after_trailing_comment` — a comment
  trailing an entry's comma, which hits the same bug via a different path.
- Full suite: `cargo test --release` (264 integration + 195 unit + 4 doctests,
  all passing), `cargo clippy --release` (clean), `cargo fmt --check` (clean).

Fixes #27.