### PR TITLE
fix(config): apply per-rule severity overrides to diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,10 @@ When no config file is found, gdstyle uses these defaults:
 
 Most rules are enabled by default with `warn` severity. Three advisory rules (`quality/type-hint`, `quality/empty-function`, `quality/no-debug-print`) are off by default and must be explicitly enabled.
 
+Severity is the CI knob: `check` exits `1` as soon as one diagnostic has
+`error` severity, and `0` when everything is a warning. Set the rules you
+want to block a build to `"error"` in `[rules]`.
+
 ## Suppressing diagnostics
 
 gdstyle has two ways to silence a warning from source: **per-line** for
@@ -599,7 +603,7 @@ When using `--format json`, gdstyle outputs a JSON array of diagnostics:
   {
     "rule": "naming/variable-name-snake-case",
     "message": "Variable 'BadName' should use snake_case: 'bad_name'",
-    "severity": "warn",
+    "severity": "warning",
     "span": {
       "line": 5,
       "column": 1

--- a/README.md
+++ b/README.md
@@ -343,7 +343,19 @@ Most rules are enabled by default with `warn` severity. Three advisory rules (`q
 
 Severity is the CI knob: `check` exits `1` as soon as one diagnostic has
 `error` severity, and `0` when everything is a warning. Set the rules you
-want to block a build to `"error"` in `[rules]`.
+want to block a build to `"error"` in `[rules]`, or use
+[`--max-warnings <N>`](#exit-codes) to cap warnings without escalating
+individual rules.
+
+A `[rules]` key that matches no known rule is reported on stderr rather
+than silently ignored, so a typo doesn't look like a setting that took
+effect:
+
+```
+$ gdstyle check
+warning: unknown rule name in [rules]: naming/variable-snake-case
+         run `gdstyle rules` to see the available rules
+```
 
 ## Suppressing diagnostics
 
@@ -508,6 +520,7 @@ gdstyle [COMMAND] [OPTIONS] [PATHS]...
 | `--select <RULES>` | Only check specific rules (comma-separated, supports partial matching) |
 | `--ignore <RULES>` | Ignore specific rules (comma-separated) |
 | `--max-line-length <N>` | Override the maximum line length |
+| `--max-warnings <N>` | Exit 1 when more than N warnings are found |
 | `--no-color` | Disable colored output |
 
 ### `fmt` options
@@ -530,8 +543,13 @@ gdstyle [COMMAND] [OPTIONS] [PATHS]...
 | Code | Meaning |
 |------|---------|
 | `0` | Linting/formatting completed (warnings only, or no issues) |
-| `1` | Linting completed with errors, or `fmt --check` found changes |
+| `1` | Linting completed with errors, `--max-warnings` was exceeded, or `fmt --check` found changes |
 | `2` | Configuration error |
+
+There are two ways to make warnings fail a build. Set the rules you care
+about to `"error"` in `[rules]` to fail on those specifically, or pass
+`--max-warnings <N>` to cap the total regardless of rule. `--max-warnings 0`
+means "no warnings at all"; `--max-warnings 5` fails only at six or more.
 
 ## CI/CD integration
 
@@ -556,6 +574,9 @@ jobs:
 
       - name: Lint GDScript files
         run: gdstyle check
+
+      # Or fail on warnings too, without escalating individual rules:
+      # run: gdstyle check --max-warnings 0
 ```
 
 ### Pre-commit hook
@@ -770,6 +791,14 @@ style.fix_at_line("res://player.gd", 12, "naming/variable-name-snake-case")
 style.set_max_line_length(120)
 style.disable_rule("format/double-quotes")
 style.load_config_res("res://gdstyle.toml")
+
+# Set a rule's severity: "off", "warn", or "error", the same vocabulary
+# gdstyle.toml uses. Returns false and logs an error for anything else.
+style.set_rule_severity("naming/variable-name-snake-case", "error")
+
+# Report [rules] keys in the loaded config that match no known rule.
+for name in style.unknown_rule_names():
+    push_warning("gdstyle: unknown rule name %s" % name)
 
 # Collect the project's .gd files the config would lint (honors exclude/include).
 # Load the config first so the walk reflects it.

--- a/gdstyle-gdext/src/lib.rs
+++ b/gdstyle-gdext/src/lib.rs
@@ -153,6 +153,40 @@ impl GdStyle {
         self.config.rules.remove(&rule_name.to_string());
     }
 
+    /// Set a rule's severity to "off", "warn", or "error", the same
+    /// vocabulary `gdstyle.toml` uses. Returns false and logs an error for
+    /// an unrecognised severity, leaving the config untouched.
+    ///
+    /// "error" is what makes a diagnostic report as an error rather than a
+    /// warning; without this, severity could only be set by loading a
+    /// config file.
+    #[func]
+    fn set_rule_severity(&mut self, rule_name: GString, severity: GString) -> bool {
+        let severity_str = severity.to_string();
+        match severity_str.parse::<gdstyle::config::RuleSeverityConfig>() {
+            Ok(parsed) => {
+                self.config.rules.insert(rule_name.to_string(), parsed);
+                true
+            }
+            Err(message) => {
+                godot_error!("gdstyle: {}", message);
+                false
+            }
+        }
+    }
+
+    /// The names in the loaded config's `[rules]` that match no known rule.
+    /// A misspelled name is silently ignored otherwise, so the config looks
+    /// like it took effect when it did nothing.
+    #[func]
+    fn unknown_rule_names(&self) -> PackedStringArray {
+        let mut arr = PackedStringArray::new();
+        for name in rules::unknown_rule_names(&self.config) {
+            arr.push(&GString::from(name));
+        }
+        arr
+    }
+
     /// Check if a specific rule is enabled.
     #[func]
     fn is_rule_enabled(&self, rule_name: GString) -> bool {

--- a/godot-plugin/addons/gdstyle/gdstyle_panel.gd
+++ b/godot-plugin/addons/gdstyle/gdstyle_panel.gd
@@ -43,6 +43,11 @@ var _gdstyle_path: String = OS.get_environment("HOME").path_join(".local/bin/gds
 var _use_gdextension: bool = false
 var _native_linter: RefCounted = null
 
+# Config file whose unknown rule names we've already reported. Warning is
+# one-shot per config because _load_nearest_config() runs on every lint,
+# and repeating it on each save would bury the output log.
+var _rules_warned_for_config: String = ""
+
 
 func _ready() -> void:
 	_detect_backend()
@@ -973,6 +978,7 @@ func _load_nearest_config(res_path: String) -> void:
 			var candidate := dir.path_join(name)
 			if FileAccess.file_exists(candidate):
 				_native_linter.load_config_res(candidate)
+				_warn_unknown_rules(candidate)
 				return
 		if dir == "res://":
 			break
@@ -981,6 +987,30 @@ func _load_nearest_config(res_path: String) -> void:
 			break
 		dir = parent
 	_native_linter.reset_config()
+	_rules_warned_for_config = ""
+
+
+## Report [rules] keys in [param config_path] that name no known rule.
+## A misspelled name parses fine and is then ignored, so without this the
+## config looks like it took effect when it silently did nothing.
+func _warn_unknown_rules(config_path: String) -> void:
+	if _rules_warned_for_config == config_path:
+		return
+	# An older GDExtension binary predates this method. Version skew must
+	# not break lint-on-save, which runs through here on every save.
+	if not _native_linter.has_method("unknown_rule_names"):
+		return
+	_rules_warned_for_config = config_path
+	var unknown: PackedStringArray = _native_linter.unknown_rule_names()
+	if unknown.is_empty():
+		return
+	push_warning(
+		"gdstyle: unknown rule %s in %s: %s" % [
+			"name" if unknown.size() == 1 else "names",
+			config_path,
+			", ".join(unknown),
+		]
+	)
 
 
 func _save_settings() -> void:

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,4 @@
+use crate::diagnostic::Severity;
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::path::Path;
@@ -137,6 +138,33 @@ impl Config {
             None => !Self::OFF_BY_DEFAULT.contains(&rule_name),
         }
     }
+
+    /// The severity a rule's diagnostics should carry, or `None` when the
+    /// config says nothing about it.
+    ///
+    /// `None` means "leave the rule's own default alone" rather than
+    /// "warning", so an error-by-default rule such as `syntax/lex-error`
+    /// keeps reporting as an error unless the config explicitly downgrades
+    /// it. `Off` also yields `None` because a disabled rule never emits.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use gdstyle::config::{Config, RuleSeverityConfig};
+    /// use gdstyle::diagnostic::Severity;
+    ///
+    /// let mut config = Config::default();
+    /// config.rules.insert("naming/function-name-snake-case".to_string(), RuleSeverityConfig::Error);
+    /// assert_eq!(config.severity_for("naming/function-name-snake-case"), Some(Severity::Error));
+    /// assert_eq!(config.severity_for("naming/variable-name-snake-case"), None);
+    /// ```
+    pub fn severity_for(&self, rule_name: &str) -> Option<Severity> {
+        match self.rules.get(rule_name) {
+            Some(RuleSeverityConfig::Warn) => Some(Severity::Warning),
+            Some(RuleSeverityConfig::Error) => Some(Severity::Error),
+            Some(RuleSeverityConfig::Off) | None => None,
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -209,6 +237,35 @@ include = ["addons/my_plugin"]
         // Existing configs that predate `include` must still parse.
         let config: Config = toml::from_str("exclude = [\"addons\"]").unwrap();
         assert!(config.include.is_empty());
+    }
+
+    #[test]
+    fn severity_for_maps_each_config_state() {
+        let mut config = Config::default();
+        config.rules.insert(
+            "naming/function-name-snake-case".to_string(),
+            RuleSeverityConfig::Error,
+        );
+        config
+            .rules
+            .insert("format/double-quotes".to_string(), RuleSeverityConfig::Warn);
+        config.rules.insert(
+            "format/trailing-whitespace".to_string(),
+            RuleSeverityConfig::Off,
+        );
+
+        assert_eq!(
+            config.severity_for("naming/function-name-snake-case"),
+            Some(Severity::Error)
+        );
+        assert_eq!(
+            config.severity_for("format/double-quotes"),
+            Some(Severity::Warning)
+        );
+        // Off never emits, so there is no severity to assign.
+        assert_eq!(config.severity_for("format/trailing-whitespace"), None);
+        // Unmentioned rules keep whatever severity the rule itself picked.
+        assert_eq!(config.severity_for("naming/variable-name-snake-case"), None);
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -65,6 +65,33 @@ pub enum RuleSeverityConfig {
     Error,
 }
 
+impl std::str::FromStr for RuleSeverityConfig {
+    type Err = String;
+
+    /// Parse the same vocabulary TOML uses, so a severity set through an
+    /// API and one set in `gdstyle.toml` can never disagree.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use gdstyle::config::RuleSeverityConfig;
+    ///
+    /// assert_eq!("error".parse(), Ok(RuleSeverityConfig::Error));
+    /// assert!("fatal".parse::<RuleSeverityConfig>().is_err());
+    /// ```
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "off" => Ok(Self::Off),
+            "warn" => Ok(Self::Warn),
+            "error" => Ok(Self::Error),
+            other => Err(format!(
+                "unknown severity {:?}, expected one of: off, warn, error",
+                other
+            )),
+        }
+    }
+}
+
 impl Default for Config {
     fn default() -> Self {
         Self {
@@ -237,6 +264,27 @@ include = ["addons/my_plugin"]
         // Existing configs that predate `include` must still parse.
         let config: Config = toml::from_str("exclude = [\"addons\"]").unwrap();
         assert!(config.include.is_empty());
+    }
+
+    #[test]
+    fn severity_config_parses_the_toml_vocabulary() {
+        use std::str::FromStr;
+        assert_eq!(
+            RuleSeverityConfig::from_str("off"),
+            Ok(RuleSeverityConfig::Off)
+        );
+        assert_eq!(
+            RuleSeverityConfig::from_str("warn"),
+            Ok(RuleSeverityConfig::Warn)
+        );
+        assert_eq!(
+            RuleSeverityConfig::from_str("error"),
+            Ok(RuleSeverityConfig::Error)
+        );
+        // "warning" is what diagnostics serialize as, but the config
+        // vocabulary is "warn", and accepting both would fork the spelling.
+        let error = RuleSeverityConfig::from_str("warning").unwrap_err();
+        assert!(error.contains("off, warn, error"), "got: {}", error);
     }
 
     #[test]

--- a/src/linter.rs
+++ b/src/linter.rs
@@ -68,6 +68,16 @@ pub fn lint_source(source: &str, file_path: &str, config: &Config) -> Vec<Diagno
     // Filter out suppressed diagnostics.
     diagnostics.retain(|d| !is_suppressed(d, &suppressed_lines));
 
+    // Apply per-rule severity overrides from the config. Rules build their
+    // diagnostics with a fixed default severity; this is the single place
+    // that knows what the user asked for. Every surface (CLI, GDExtension,
+    // formatter) funnels through here, so one pass covers them all.
+    for diagnostic in &mut diagnostics {
+        if let Some(severity) = config.severity_for(&diagnostic.rule) {
+            diagnostic.severity = severity;
+        }
+    }
+
     diagnostics
 }
 
@@ -486,6 +496,67 @@ func take_damage(amount: int) -> void:
         assert!(!diagnostics
             .iter()
             .any(|d| d.rule == "naming/class-name-pascal-case"));
+    }
+
+    #[test]
+    fn config_escalates_rule_to_error() {
+        // The reported bug: `"rule" = "error"` parsed fine but every
+        // diagnostic still came out as a warning, so `check` exited 0.
+        let source = "var BadName: int = 5\n\nfunc DoThing() -> void:\n\tpass\n";
+        let mut config = Config::default();
+        for rule in [
+            "naming/variable-name-snake-case",
+            "naming/function-name-snake-case",
+        ] {
+            config
+                .rules
+                .insert(rule.to_string(), crate::config::RuleSeverityConfig::Error);
+        }
+
+        let diagnostics = lint_source(source, "bad_test.gd", &config);
+        let escalated: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.rule.starts_with("naming/"))
+            .collect();
+        assert_eq!(escalated.len(), 2, "got: {:?}", diagnostics);
+        assert!(
+            escalated
+                .iter()
+                .all(|d| d.severity == crate::diagnostic::Severity::Error),
+            "configured rules must report as errors, got: {:?}",
+            escalated
+        );
+    }
+
+    #[test]
+    fn unconfigured_rule_keeps_default_warning_severity() {
+        let source = "var BadName: int = 5\n";
+        let diagnostics = lint_source(source, "test.gd", &Config::default());
+        let diagnostic = diagnostics
+            .iter()
+            .find(|d| d.rule == "naming/variable-name-snake-case")
+            .expect("naming diagnostic");
+        assert_eq!(diagnostic.severity, crate::diagnostic::Severity::Warning);
+    }
+
+    #[test]
+    fn config_downgrades_error_by_default_rule() {
+        // `syntax/lex-error` is the one rule that defaults to Error. An
+        // unmentioned rule must keep that default (guarded by
+        // `lint_surfaces_unterminated_string_as_error`), but an explicit
+        // `"warn"` must still be able to downgrade it.
+        let source = "var x = \"oops\nvar y = 5\n";
+        let mut config = Config::default();
+        config.rules.insert(
+            "syntax/lex-error".to_string(),
+            crate::config::RuleSeverityConfig::Warn,
+        );
+        let diagnostics = lint_source(source, "test.gd", &config);
+        let lex_error = diagnostics
+            .iter()
+            .find(|d| d.rule == "syntax/lex-error")
+            .expect("lex error diagnostic");
+        assert_eq!(lex_error.severity, crate::diagnostic::Severity::Warning);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,6 +53,10 @@ struct Cli {
     #[arg(long)]
     max_line_length: Option<usize>,
 
+    /// Exit 1 when more than this many warnings are found.
+    #[arg(long)]
+    max_warnings: Option<usize>,
+
     /// Disable colored output.
     #[arg(long)]
     no_color: bool,
@@ -101,6 +105,10 @@ enum Commands {
         /// Maximum line length override.
         #[arg(long)]
         max_line_length: Option<usize>,
+
+        /// Exit 1 when more than this many warnings are found.
+        #[arg(long)]
+        max_warnings: Option<usize>,
 
         /// Disable colored output.
         #[arg(long)]
@@ -155,19 +163,21 @@ fn main() {
             select,
             ignore,
             max_line_length,
+            max_warnings,
             no_color,
         }) => {
-            run_check(
-                &paths,
+            run_check(CheckOptions {
+                paths: &paths,
                 fix,
                 unsafe_fix,
-                &format,
-                config.as_deref(),
-                select.as_deref(),
-                ignore.as_deref(),
+                format: &format,
+                config_path: config.as_deref(),
+                select: select.as_deref(),
+                ignore: ignore.as_deref(),
                 max_line_length,
+                max_warnings,
                 no_color,
-            );
+            });
         }
         Some(Commands::Fmt {
             paths,
@@ -188,33 +198,70 @@ fn main() {
             run_init(force);
         }
         None => {
-            run_check(
-                &cli.paths,
-                cli.fix,
-                cli.unsafe_fix,
-                &cli.format,
-                cli.config.as_deref(),
-                cli.select.as_deref(),
-                cli.ignore.as_deref(),
-                cli.max_line_length,
-                cli.no_color,
-            );
+            run_check(CheckOptions {
+                paths: &cli.paths,
+                fix: cli.fix,
+                unsafe_fix: cli.unsafe_fix,
+                format: &cli.format,
+                config_path: cli.config.as_deref(),
+                select: cli.select.as_deref(),
+                ignore: cli.ignore.as_deref(),
+                max_line_length: cli.max_line_length,
+                max_warnings: cli.max_warnings,
+                no_color: cli.no_color,
+            });
         }
     }
 }
 
-#[allow(clippy::too_many_arguments)]
-fn run_check(
-    paths: &[PathBuf],
+/// Everything `run_check` needs from the CLI. The same options are
+/// reachable both as `gdstyle check ...` and as a bare `gdstyle ...`, so
+/// bundling them keeps the two call sites from drifting apart as flags
+/// are added.
+struct CheckOptions<'a> {
+    paths: &'a [PathBuf],
     fix: bool,
     unsafe_fix: bool,
-    format: &str,
-    config_path: Option<&Path>,
-    select: Option<&str>,
-    ignore: Option<&str>,
+    format: &'a str,
+    config_path: Option<&'a Path>,
+    select: Option<&'a str>,
+    ignore: Option<&'a str>,
     max_line_length: Option<usize>,
+    max_warnings: Option<usize>,
     no_color: bool,
-) {
+}
+
+/// Warn about `[rules]` entries naming no known rule. A misspelled name
+/// is valid TOML and is then ignored, so without this the config looks
+/// like it took effect when it silently did nothing.
+fn warn_unknown_rules(config: &Config) {
+    let unknown = rules::unknown_rule_names(config);
+    if unknown.is_empty() {
+        return;
+    }
+    eprintln!(
+        "{}: unknown rule {} in [rules]: {}",
+        "warning".yellow(),
+        if unknown.len() == 1 { "name" } else { "names" },
+        unknown.join(", ")
+    );
+    eprintln!("         run `gdstyle rules` to see the available rules");
+}
+
+fn run_check(options: CheckOptions) {
+    let CheckOptions {
+        paths,
+        fix,
+        unsafe_fix,
+        format,
+        config_path,
+        select,
+        ignore,
+        max_line_length,
+        max_warnings,
+        no_color,
+    } = options;
+
     if no_color {
         colored::control::set_override(false);
     }
@@ -233,6 +280,8 @@ fn run_check(
             Config::find_and_load(&cwd)
         }
     };
+
+    warn_unknown_rules(&config);
 
     // Apply CLI overrides.
     if let Some(max_len) = max_line_length {
@@ -502,6 +551,26 @@ fn run_check(
     if has_errors {
         process::exit(1);
     }
+
+    // `--max-warnings` is the escape hatch for projects that want CI to
+    // fail on warnings without escalating every rule to "error". Reported
+    // on stderr so `--format json` keeps stdout machine-readable.
+    if let Some(limit) = max_warnings {
+        let warning_count = all_diagnostics
+            .iter()
+            .filter(|d| d.severity == Severity::Warning)
+            .count();
+        if warning_count > limit {
+            eprintln!(
+                "{}: {} warning{} found, exceeding the --max-warnings limit of {}",
+                "error".red(),
+                warning_count,
+                if warning_count == 1 { "" } else { "s" },
+                limit
+            );
+            process::exit(1);
+        }
+    }
 }
 
 fn run_fmt(paths: &[PathBuf], check: bool, diff: bool, config_path: Option<&Path>, no_color: bool) {
@@ -522,6 +591,10 @@ fn run_fmt(paths: &[PathBuf], check: bool, diff: bool, config_path: Option<&Path
             Config::find_and_load(&cwd)
         }
     };
+
+    // `fmt` applies safe lint fixes too, so a typo'd rule name silently
+    // changes what gets formatted just as it changes what gets reported.
+    warn_unknown_rules(&config);
 
     let filter = PathFilter::new(&config.exclude, &config.include);
     let files = collect_gdscript_files(paths, &filter);

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -20,7 +20,7 @@ pub fn run_all_rules(file: &ScriptFile, tokens: &[Token], config: &Config) -> Ve
 /// Run all enabled lint rules, optionally with source for token-gap analysis.
 ///
 /// Like [`run_all_rules`], this does not apply the config's severity
-/// overrides — see [`crate::linter::lint_source`].
+/// overrides. See [`crate::linter::lint_source`].
 pub fn run_all_rules_with_source(
     file: &ScriptFile,
     tokens: &[Token],
@@ -443,4 +443,76 @@ pub fn all_rules() -> &'static [(&'static str, &'static str)] {
 
 pub fn all_rule_names() -> Vec<&'static str> {
     all_rules().iter().map(|(name, _)| *name).collect()
+}
+
+/// The `[rules]` keys in `config` that match no rule in the registry,
+/// sorted for stable output.
+///
+/// A misspelled rule name parses as valid TOML and is then silently
+/// ignored, so the config looks like it took effect when it did not.
+/// Callers surface this to the user; the registry is what decides.
+///
+/// # Example
+///
+/// ```
+/// use gdstyle::config::{Config, RuleSeverityConfig};
+/// use gdstyle::rules;
+///
+/// let mut config = Config::default();
+/// config.rules.insert("naming/variable-snake-case".to_string(), RuleSeverityConfig::Error);
+/// assert_eq!(rules::unknown_rule_names(&config), vec!["naming/variable-snake-case"]);
+/// ```
+pub fn unknown_rule_names(config: &Config) -> Vec<&str> {
+    let known = all_rule_names();
+    let mut unknown: Vec<&str> = config
+        .rules
+        .keys()
+        .map(String::as_str)
+        .filter(|name| !known.contains(name))
+        .collect();
+    unknown.sort_unstable();
+    unknown
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::RuleSeverityConfig;
+
+    #[test]
+    fn unknown_rule_names_flags_only_misspellings() {
+        let mut config = Config::default();
+        // A real rule, a near-miss typo, and something entirely made up.
+        for name in [
+            "naming/variable-name-snake-case",
+            "naming/variable-snake-case",
+            "format/tabs",
+        ] {
+            config
+                .rules
+                .insert(name.to_string(), RuleSeverityConfig::Error);
+        }
+        assert_eq!(
+            unknown_rule_names(&config),
+            vec!["format/tabs", "naming/variable-snake-case"]
+        );
+    }
+
+    #[test]
+    fn every_registry_name_is_accepted() {
+        // Guards against the registry and the validator drifting apart:
+        // a config naming every rule must report nothing unknown.
+        let mut config = Config::default();
+        for name in all_rule_names() {
+            config
+                .rules
+                .insert(name.to_string(), RuleSeverityConfig::Warn);
+        }
+        assert!(unknown_rule_names(&config).is_empty());
+    }
+
+    #[test]
+    fn default_config_has_no_unknown_rules() {
+        assert!(unknown_rule_names(&Config::default()).is_empty());
+    }
 }

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -9,11 +9,18 @@ use crate::diagnostic::Diagnostic;
 use crate::token::Token;
 
 /// Run all enabled lint rules on a parsed script file.
+///
+/// Diagnostics come back with each rule's own default severity; the
+/// `[rules]` severity overrides are applied by [`crate::linter::lint_source`],
+/// which is the entry point most callers want.
 pub fn run_all_rules(file: &ScriptFile, tokens: &[Token], config: &Config) -> Vec<Diagnostic> {
     run_all_rules_with_source(file, tokens, config, None)
 }
 
 /// Run all enabled lint rules, optionally with source for token-gap analysis.
+///
+/// Like [`run_all_rules`], this does not apply the config's severity
+/// overrides — see [`crate::linter::lint_source`].
 pub fn run_all_rules_with_source(
     file: &ScriptFile,
     tokens: &[Token],

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -231,7 +231,7 @@ fn fmt_also_reports_unknown_rule_names() {
 fn the_generated_config_names_only_real_rules() {
     // `gdstyle init` writes a template listing every rule. Now that an
     // unrecognised name is reported, the tool's own output must pass its
-    // own validation — this catches a rule renamed in the registry but
+    // own validation. This catches a rule renamed in the registry but
     // not in the template.
     let dir = tempfile::tempdir().expect("temp dir");
     let status = Command::new(env!("CARGO_BIN_EXE_gdstyle"))

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -1,0 +1,262 @@
+//! Tests that drive the `gdstyle` binary itself.
+//!
+//! Exit codes and the messages printed alongside them live in `main.rs`, so
+//! they can't be reached from the library tests in `integration_test.rs`.
+//! Every test passes `--config` explicitly rather than relying on the
+//! upward config search, so results don't depend on what sits above the
+//! temporary directory.
+
+use std::path::Path;
+use std::process::{Command, Output};
+
+/// A script with exactly two naming violations: one variable, one function.
+const TWO_VIOLATIONS: &str =
+    "extends Node\n\nvar BadName: int = 5\n\nfunc DoThing() -> void:\n\tpass\n";
+
+struct Project {
+    _dir: tempfile::TempDir,
+    config: std::path::PathBuf,
+    script: std::path::PathBuf,
+}
+
+/// Write a config and a script into a fresh temporary directory.
+fn project(config_body: &str, source: &str) -> Project {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let config = dir.path().join("gdstyle.toml");
+    let script = dir.path().join("bad_test.gd");
+    std::fs::write(&config, config_body).expect("write config");
+    std::fs::write(&script, source).expect("write script");
+    Project {
+        _dir: dir,
+        config,
+        script,
+    }
+}
+
+fn check(config: &Path, script: &Path, extra: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_gdstyle"))
+        .arg("check")
+        .arg(script)
+        .arg("--config")
+        .arg(config)
+        .arg("--no-color")
+        .args(extra)
+        .output()
+        .expect("run gdstyle")
+}
+
+fn stdout_of(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+fn stderr_of(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stderr).into_owned()
+}
+
+#[test]
+fn error_severity_makes_check_exit_1() {
+    // The reported bug end to end: rules set to "error" printed as
+    // warnings and `check` exited 0, so CI stayed green.
+    let p = project(
+        "[rules]\n\
+         \"naming/variable-name-snake-case\" = \"error\"\n\
+         \"naming/function-name-snake-case\" = \"error\"\n",
+        TWO_VIOLATIONS,
+    );
+    let output = check(&p.config, &p.script, &[]);
+    let stdout = stdout_of(&output);
+
+    assert_eq!(output.status.code(), Some(1), "stdout:\n{}", stdout);
+    assert!(
+        stdout.contains("2 errors found"),
+        "summary should count errors; got:\n{}",
+        stdout
+    );
+    assert!(
+        !stdout.contains("warning"),
+        "no diagnostic should print as a warning; got:\n{}",
+        stdout
+    );
+}
+
+#[test]
+fn warnings_alone_still_exit_0() {
+    // The documented default: warnings report but don't fail a build.
+    let p = project("[rules]\n", TWO_VIOLATIONS);
+    let output = check(&p.config, &p.script, &[]);
+    let stdout = stdout_of(&output);
+
+    assert_eq!(output.status.code(), Some(0), "stdout:\n{}", stdout);
+    assert!(stdout.contains("2 warnings found"), "got:\n{}", stdout);
+}
+
+#[test]
+fn max_warnings_fails_when_the_count_exceeds_the_limit() {
+    let p = project("[rules]\n", TWO_VIOLATIONS);
+    let output = check(&p.config, &p.script, &["--max-warnings", "1"]);
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "stdout:\n{}",
+        stdout_of(&output)
+    );
+    assert!(
+        stderr_of(&output).contains("2 warnings found, exceeding the --max-warnings limit of 1"),
+        "should explain why it failed; got stderr:\n{}",
+        stderr_of(&output)
+    );
+}
+
+#[test]
+fn max_warnings_passes_when_the_count_equals_the_limit() {
+    // Boundary: the limit is a maximum, so N warnings under `--max-warnings N`
+    // is a pass. Only N+1 fails.
+    let p = project("[rules]\n", TWO_VIOLATIONS);
+    let output = check(&p.config, &p.script, &["--max-warnings", "2"]);
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stdout:\n{}",
+        stdout_of(&output)
+    );
+}
+
+#[test]
+fn max_warnings_ignores_diagnostics_escalated_to_error() {
+    // Errors already fail on their own, and they must not also be counted
+    // against the warning budget: `--max-warnings 0` with one error and no
+    // warnings should report the error, not a bogus warning overflow.
+    let p = project(
+        "[rules]\n\"naming/variable-name-snake-case\" = \"error\"\n\
+         \"naming/function-name-snake-case\" = \"off\"\n",
+        TWO_VIOLATIONS,
+    );
+    let output = check(&p.config, &p.script, &["--max-warnings", "0"]);
+
+    assert_eq!(output.status.code(), Some(1));
+    assert!(
+        !stderr_of(&output).contains("--max-warnings"),
+        "an error should fail before the warning budget is consulted; got stderr:\n{}",
+        stderr_of(&output)
+    );
+}
+
+#[test]
+fn max_warnings_keeps_json_stdout_parsable() {
+    // The failure note goes to stderr so `--format json` stays machine-readable.
+    let p = project("[rules]\n", TWO_VIOLATIONS);
+    let output = Command::new(env!("CARGO_BIN_EXE_gdstyle"))
+        .arg("check")
+        .arg(&p.script)
+        .arg("--config")
+        .arg(&p.config)
+        .arg("--format")
+        .arg("json")
+        .arg("--max-warnings")
+        .arg("0")
+        .output()
+        .expect("run gdstyle");
+
+    assert_eq!(output.status.code(), Some(1));
+    let stdout = stdout_of(&output);
+    let parsed: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("stdout should be valid JSON ({}); got:\n{}", e, stdout));
+    assert_eq!(parsed.as_array().map(Vec::len), Some(2));
+}
+
+#[test]
+fn unknown_rule_names_are_reported() {
+    // A misspelled rule name is valid TOML and was silently ignored, so
+    // the config looked like it took effect when it did nothing.
+    let p = project(
+        "[rules]\n\
+         \"naming/variable-snake-case\" = \"error\"\n\
+         \"format/tabs\" = \"off\"\n",
+        TWO_VIOLATIONS,
+    );
+    let output = check(&p.config, &p.script, &[]);
+    let stderr = stderr_of(&output);
+
+    assert!(
+        stderr.contains("unknown rule names in [rules]: format/tabs, naming/variable-snake-case"),
+        "both typos should be listed, sorted; got stderr:\n{}",
+        stderr
+    );
+    assert!(
+        stderr.contains("gdstyle rules"),
+        "should point at the rule listing; got stderr:\n{}",
+        stderr
+    );
+}
+
+#[test]
+fn a_correct_config_reports_no_unknown_rules() {
+    let p = project(
+        "[rules]\n\"naming/variable-name-snake-case\" = \"error\"\n",
+        TWO_VIOLATIONS,
+    );
+    let output = check(&p.config, &p.script, &[]);
+
+    assert!(
+        !stderr_of(&output).contains("unknown rule"),
+        "a valid config must stay quiet; got stderr:\n{}",
+        stderr_of(&output)
+    );
+}
+
+#[test]
+fn fmt_also_reports_unknown_rule_names() {
+    // `fmt` applies safe lint fixes, so a typo changes what gets formatted
+    // just as it changes what gets reported.
+    let p = project("[rules]\n\"format/tabs\" = \"off\"\n", TWO_VIOLATIONS);
+    let output = Command::new(env!("CARGO_BIN_EXE_gdstyle"))
+        .arg("fmt")
+        .arg(&p.script)
+        .arg("--config")
+        .arg(&p.config)
+        .arg("--no-color")
+        .output()
+        .expect("run gdstyle");
+
+    assert!(
+        stderr_of(&output).contains("unknown rule name in [rules]: format/tabs"),
+        "a single typo should be singular; got stderr:\n{}",
+        stderr_of(&output)
+    );
+}
+
+#[test]
+fn the_generated_config_names_only_real_rules() {
+    // `gdstyle init` writes a template listing every rule. Now that an
+    // unrecognised name is reported, the tool's own output must pass its
+    // own validation — this catches a rule renamed in the registry but
+    // not in the template.
+    let dir = tempfile::tempdir().expect("temp dir");
+    let status = Command::new(env!("CARGO_BIN_EXE_gdstyle"))
+        .arg("init")
+        .current_dir(dir.path())
+        .status()
+        .expect("run gdstyle init");
+    assert!(status.success());
+
+    let template = std::fs::read_to_string(dir.path().join("gdstyle.toml")).expect("read template");
+    let known = gdstyle::rules::all_rule_names();
+    // Only the keys under `[rules]`; other tables quote paths, not rules.
+    let named: Vec<&str> = template
+        .lines()
+        .skip_while(|line| line.trim() != "[rules]")
+        .filter(|line| line.contains('='))
+        .filter_map(|line| line.split('"').nth(1))
+        .collect();
+
+    assert!(!named.is_empty(), "template should name some rules");
+    for name in named {
+        assert!(
+            known.contains(&name),
+            "template names {:?}, which is not in the rule registry",
+            name
+        );
+    }
+}

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -260,3 +260,46 @@ fn the_generated_config_names_only_real_rules() {
         );
     }
 }
+
+#[test]
+fn issue_29_full_user_config() {
+    // The reporter's own files, kept verbatim in tests/fixtures/issue29:
+    // a config setting every rule to "error" and a script violating two of
+    // them. Reported as warnings with exit 0; must be errors with exit 1.
+    let fixtures = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join("issue29");
+    let output = check(
+        &fixtures.join("gdstyle.toml"),
+        &fixtures.join("bad_test.gd"),
+        &[],
+    );
+    let stdout = stdout_of(&output);
+
+    assert_eq!(output.status.code(), Some(1), "stdout:\n{}", stdout);
+    assert!(stdout.contains("2 errors found"), "got:\n{}", stdout);
+    for expected in [
+        "3:1 error variable name \'BadName\'",
+        "5:1 error function name \'DoThing\'",
+    ] {
+        assert!(
+            stdout.contains(expected),
+            "missing {:?}; got:\n{}",
+            expected,
+            stdout
+        );
+    }
+    assert!(
+        !stdout.contains("warning"),
+        "nothing should report as a warning; got:\n{}",
+        stdout
+    );
+    // Every name in that config is real, so it must not trip the new
+    // unknown-rule warning either.
+    assert!(
+        !stderr_of(&output).contains("unknown rule"),
+        "the reported config is valid; got stderr:\n{}",
+        stderr_of(&output)
+    );
+}

--- a/tests/fixtures/issue29/README.md
+++ b/tests/fixtures/issue29/README.md
@@ -1,0 +1,7 @@
+Verbatim reproduction from issue #29: a config setting every rule to
+`"error"` next to a file that violates two of them. Both diagnostics
+reported as warnings and `check` exited 0, so CI could never fail.
+
+Kept byte-for-byte as reported (`bad_test.gd` is deliberately not
+formatted) so `issue_29_full_user_config` reproduces the original
+line numbers.

--- a/tests/fixtures/issue29/bad_test.gd
+++ b/tests/fixtures/issue29/bad_test.gd
@@ -1,0 +1,6 @@
+extends Node
+
+var BadName: int = 5
+
+func DoThing() -> void:
+	pass

--- a/tests/fixtures/issue29/gdstyle.toml
+++ b/tests/fixtures/issue29/gdstyle.toml
@@ -1,0 +1,71 @@
+# gdstyle.toml: starter configuration
+#
+# Place this file as `gdstyle.toml` or `.gdstyle.toml` in your project root.
+# gdstyle will search for it starting from the current directory and walking
+# up the directory tree.
+
+# Maximum line length (default: 100)
+max_line_length = 100
+
+# Use tabs for indentation (default: true).
+# Set to false if your project uses spaces.
+use_tabs = true
+
+# Maximum function body length in lines (default: 50)
+max_function_length = 50
+
+# Maximum file length in lines (default: 1000)
+max_file_length = 500
+
+# Maximum number of function parameters (default: 5)
+max_parameters = 5
+
+# File and directory patterns to exclude from linting.
+# These are matched as glob patterns against file paths.
+exclude = [".godot", "addons"]
+
+# Per-rule severity overrides.
+# Values: "off" (disable), "warn" (warning), "error" (error)
+#
+# All rules are enabled with "warn" severity by default.
+# Uncomment any line below to change its severity.
+[rules]
+# --- Naming ---
+"naming/class-name-pascal-case" = "error"
+"naming/function-name-snake-case" = "error"
+"naming/variable-name-snake-case" = "error"
+"naming/constant-name-screaming-case" = "error"
+"naming/signal-name-snake-case" = "error"
+"naming/enum-name-pascal-case" = "error"
+"naming/enum-member-screaming-case" = "error"
+"naming/file-name-snake-case" = "error"
+"naming/signal-past-tense" = "error"
+"naming/private-underscore-prefix" = "error"
+"naming/node-name-pascal-case" = "error"
+
+# --- Formatting ---
+"format/max-line-length" = "error"
+"format/trailing-whitespace" = "error"
+"format/trailing-newline" = "error"
+"format/no-tabs-as-spaces" = "error"
+"format/boolean-operators" = "error"
+"format/double-quotes" = "error"
+"format/comment-spacing" = "error"
+"format/no-unnecessary-parens" = "error"
+"format/number-literals" = "error"
+"format/one-statement-per-line" = "error"
+"format/blank-lines" = "error"
+"format/trailing-comma" = "error"
+"format/operator-spacing" = "error"
+"format/float-literal-zeros" = "error"
+"format/large-number-underscores" = "error"
+"format/enum-one-per-line" = "error"
+
+# --- Ordering ---
+"order/class-member-order" = "error"
+
+# --- Quality ---
+"quality/max-function-length" = "error"
+"quality/max-file-length" = "error"
+"quality/max-parameters" = "error"
+"quality/no-debug-print" = "error"

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -6053,3 +6053,55 @@ var xs := [
         formatted
     );
 }
+
+/// End-to-end reproduction of the reported severity bug: a `gdstyle.toml`
+/// setting rules to `"error"` next to a file that violates them. Before the
+/// fix both diagnostics came back as warnings and the summary read
+/// "2 warnings found", so `check` exited 0 and CI stayed green.
+#[test]
+fn toml_error_severity_reaches_diagnostics_and_summary() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    std::fs::write(
+        dir.path().join("gdstyle.toml"),
+        "[rules]\n\
+         \"naming/variable-name-snake-case\" = \"error\"\n\
+         \"naming/function-name-snake-case\" = \"error\"\n",
+    )
+    .expect("write config");
+
+    let script = dir.path().join("bad_test.gd");
+    std::fs::write(
+        &script,
+        "extends Node\n\nvar BadName: int = 5\n\nfunc DoThing() -> void:\n\tpass\n",
+    )
+    .expect("write script");
+
+    let config = Config::find_and_load(dir.path());
+    let diagnostics = linter::lint_file(&script, &config).expect("lint");
+
+    assert_eq!(
+        diagnostics.len(),
+        2,
+        "expected exactly the two naming diagnostics, got: {:?}",
+        diagnostics
+    );
+    assert!(
+        diagnostics
+            .iter()
+            .all(|d| d.severity == gdstyle::diagnostic::Severity::Error),
+        "rules configured as \"error\" must report as errors, got: {:?}",
+        diagnostics
+    );
+
+    // `check` exits 1 on exactly this predicate (see `run_check` in main.rs).
+    assert!(diagnostics
+        .iter()
+        .any(|d| d.severity == gdstyle::diagnostic::Severity::Error));
+
+    let summary = gdstyle::reporter::format_summary(&diagnostics, 1);
+    assert!(
+        summary.contains("2 errors") && !summary.contains("warning"),
+        "summary should count errors, not warnings; got: {}",
+        summary
+    );
+}


### PR DESCRIPTION
## Summary

Per-rule `"error"` severity in `gdstyle.toml` was parsed and then thrown away, so every diagnostic printed as a warning and `check` always exited `0`. This fixes that, and closes the two adjacent gaps that made it hard to diagnose and hard to work around.

**The bug.** `Config::rules` is three-valued (`off`/`warn`/`error`), but the only accessor reading it was `is_rule_enabled`, which collapses it to a boolean: `Off` → false, everything else → true. The `Warn`/`Error` distinction was discarded, every rule emitted `Diagnostic::warning`, and since `check` exits 1 on `any(severity == Error)`, no amount of `"error"` in a config could fail a build. `Config::severity_for` now supplies the missing read, applied in `lint_source`, the single funnel the CLI, GDExtension, and formatter all pass through. It returns `Option<Severity>` rather than defaulting to `Warning`, so an absent entry means "keep the rule's own default": `syntax/lex-error` stays an error, while an explicit `"warn"` can still downgrade it.

**Unknown rule names.** A misspelled `[rules]` key is valid TOML and was then dropped on the floor, so a config looked like it took effect when it silently did nothing. That is the failure mode that made this bug hard to spot in the first place. `rules::unknown_rule_names` validates keys against the registry; `check` and `fmt` report them on stderr, and the editor plugin pushes a warning once per config file. A warning rather than a hard config error: an unknown key is harmless, and failing outright would break configs written against a different version.

**`--max-warnings <N>`.** With a default config there was no way to fail CI on warnings at all. `check` now exits 1 when the warning count exceeds the limit, ESLint-style, so `--max-warnings 0` means "no warnings" without escalating rules one by one. The note goes to stderr so `--format json` keeps stdout machine-readable.

**GDScript severity.** `GdStyle.set_rule_severity(rule, "off"|"warn"|"error")` fills the gap next to the existing `disable_rule`/`enable_rule`; previously severity could only be set by loading a config file. It shares `RuleSeverityConfig::FromStr` with the TOML loader so the two vocabularies cannot drift. `GdStyle.unknown_rule_names()` exposes the validation to plugin code.

## Type

- [x] Bug fix (`fix:`) — non-breaking change that resolves an issue
- [x] New feature (`feat:`) — non-breaking change that adds functionality
- [ ] New lint rule (`feat:`)
- [ ] Refactor (`refactor:`) — no behaviour change
- [ ] Performance (`perf:`)
- [x] Documentation (`docs:`)
- [ ] CI / build (`ci:` / `build:`)
- [ ] Breaking change

## Test plan

The issue's repro, before → after:

```
3:1 warning variable name 'BadName' ...   →   3:1 error variable name 'BadName' ...
5:1 warning function name 'DoThing' ...   →   5:1 error function name 'DoThing' ...
1 file checked, 2 warnings found.         →   1 file checked, 2 errors found.
exit=0                                    →   exit=1
```

New `tests/cli_test.rs` drives the binary itself, since exit codes and the messages beside them live in `main.rs` and can't be reached from the library tests: the repro above end to end, warnings alone still exiting 0, `--max-warnings` at and over the limit, errors not counting against the warning budget, JSON stdout staying parsable when the limit trips, unknown names reported by both `check` and `fmt`, and a clean config staying quiet. One of them checks that `gdstyle init`'s own generated template names only real rules, so the tool passes its own new validation.

Library tests cover `severity_for` across all four config states, `FromStr` rejecting `"warning"` (diagnostics serialize as `warning`, but the config vocabulary is `warn`), escalation to error, unconfigured rules staying warnings, explicit `"warn"` downgrading the one error-by-default rule, `unknown_rule_names` against typos and against the full registry, and an end-to-end pass through the real `Config::find_and_load` TOML path.

`lint_source` is shared with the formatter's `lint_then_fix`, so I confirmed `fmt examples/` produces a byte-identical diff on this branch and on `main`. The plugin change is GDScript and not reachable from CI, so it is guarded with `has_method` against a version-skewed `.so` and adds no new diagnostics under `gdstyle check` (17 before, 17 after).

- [x] `cargo test` passes locally — 494 total, 0 failed, plus `cargo test -p gdstyle-gdext`
- [x] `cargo clippy --release --all-targets` is clean (zero warnings)
- [x] If this touches a rule or the formatter: relevant regression tests added

## Docs

- README: severity and `--max-warnings` as the two ways to fail a build, the unknown-rule warning with sample output, `--max-warnings` in the `check` options and exit-code tables and the CI example, and the two new GDExtension methods
- README: the JSON example said `"severity": "warn"`; `Severity` serializes as `"warning"`
- `run_all_rules` is public but returns rule-default severities, so it now points callers at `lint_source`

## Linked issues

Closes #29
